### PR TITLE
feat: 行動前に成功確率を表示 (#28)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,6 +163,11 @@ Right pane layout:
       - full:    `RARE COOLDOWN [████████████] ⚡ レア出現確率上昇中!`
       - 進捗値は `CurionGenerator::generate_with_bonus` に渡されて roll を最大 0.3 だけ引き下げる
       - `Player::last_collection_at` に最終収集時刻を記録 (旧セーブ・新規セーブは None=フルチャージ扱い)
+    - Paragraph: RARE 出現確率 (Issue #28, 1 行)
+      - `RARE出現確率: 12.3%  (Common 47.7% / Rare 30.0% / Epic 9.0% / Legendary 1.0%)`
+      - cooldown progress 反映済み。レア以上は Cyan+Bold (満タン時は Epic 色)、内訳は Label color
+      - 確率は `crate::cooldown::current_rarity_probabilities(progress)` がロジック層で算出
+      - generator の roll-shift モデル (累積境界 0.01 / 0.10 / 0.40 + `0.3*progress` シフト) と整合
     - Paragraph: 総獲得数 / 今日の獲得 / レベル / COMBO (one line, inline)
       - COMBO: N — Common でリセット、Rare 以上で +1
       - 表示色: 0/1=Label, 2=Rare, 3-4=Epic, 5+=Legendary + `🔥 コンボマスター!`
@@ -300,10 +305,14 @@ Right pane layout:
 ```
 レシピ一覧 (section 0):
   - Scrollable list of all recipes
-  - Each item (3 lines):
+  - Each item (4 lines):
     Line 1: ✓/? RecipeName (bold White)
     Line 2:     Description -> ResultName (discovered) or ??? (undiscovered)
-    Line 3: (blank)
+    Line 3:     合成確率: NN% [████████░░] (Issue #28)
+              - undiscovered: Cyan ratio bar + cyan percentage (= discovery_rate)
+              - discovered:   Green 100% + green full bar (確定成功)
+              - 10-cell bar, percentage は `round()` で整数化
+    Line 4: (blank)
   - ✓ = Green (discovered), ? = DarkGray (undiscovered)
 
 合成実行 (section 1):
@@ -316,6 +325,9 @@ Right pane layout:
   Phase B — SelectingSecond:
     Left half: "Selected" (unfocused_block) — first ingredient details in Green
     Right half: "Select Ingredient 2" (focused_block) — candidate list
+      - 各候補行末尾に「合成確率 NN% [████████░░]」を 8-cell bar 付きで表示 (Issue #28)
+      - 確率値は (Ingredient 1, 候補) ペアで最初にマッチするレシピを基準
+      - 計算ロジックは `SynthesisManager::success_probability_for_recipe`
 
   Active selection highlight: bg(Cyan) fg(Black) Bold
   Empty state: fg(Red), "No curions / No possible combinations"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,6 +63,7 @@
 - [x] コレクション正規表現絞り込み (#31) — Collection タブで `/` から正規表現を入力し、所持一覧と図鑑をリアルタイムフィルタ
 - [x] レア出現予告クールダウン (#25) — 収集後 4 時間でレア確率が段階的に上昇、Dashboard 概要に LineGauge 表示
 - [x] きりの悪い数字設計 (#32) — XP 閾値を非線形テーブル化、実績閾値を割り切れない値にずらし、Dashboard に「next milestone (あと N)」を常時表示
+- [x] 行動前に成功確率を表示する (#28) — Synthesis レシピ一覧と Ingredient 2 候補に「合成確率 NN% [████████░░]」を表示し、Dashboard 概要には cooldown 込みの現在のレアリティ別出現確率を 1 行で表示 (計算は `cooldown::current_rarity_probabilities` / `SynthesisRecipe::success_probability` でロジック層に閉じる)
 - [ ] イベントシステム
 - [ ] ランキング
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -135,6 +135,14 @@ Left pane sections:
   - `Player::last_collection_at` (`#[serde(default) = None]`) holds the timestamp;
     `add_curion` refreshes it. `None` (= fresh save / legacy save) is treated as
     fully charged so the very first acquisition starts with the bonus.
+- **RARE 出現確率** (Issue #28):
+  - Cooldown progress 反映済みの現在のレアリティ別出現確率を 1 行で表示
+  - 例: `RARE出現確率: 12.3%  (Common 47.7% / Rare 30.0% / Epic 9.0% / Legendary 1.0%)`
+  - 「レア以上 = Rare + Epic + Legendary」を強調色で出す
+  - 計算ロジックは `crate::cooldown::current_rarity_probabilities(progress)` に閉じ込め、
+    UI は値を読み取って整形するだけ。
+  - generator の roll-shift モデルと整合: 累積確率境界 (0.01 / 0.10 / 0.40) に
+    `0.3 * progress` を加算 → クランプして 4 帯の確率を算出。
 - **Next milestone hint** (Issue #32):
   `next milestone: ⭐ コレクター Lv.3 (あと 4 個)` 形式の 1 行表示。
   XP / 未解除実績 (TotalCount / RarityCount / CategoryCount / SpecificNoun / ConsecutiveLogin
@@ -251,6 +259,17 @@ Left pane sections:
 Right pane behavior:
 - Recipe List: discovered/undiscovered recipe index
 - Synthesize: two-step ingredient selection flow
+
+**Synthesis success probability (Issue #28):**
+- Each recipe row in the Recipe List shows its success probability with a 10-cell bar:
+  - Undiscovered: cyan `合成確率:  78% [████████░░]` (= `discovery_rate`)
+  - Discovered:   green `合成確率: 100% [██████████]` (= 1.0)
+- During Ingredient 2 selection, each candidate is suffixed with the actual recipe's
+  success probability for the (Ingredient 1, candidate) pair, e.g.
+  `... 水 (×3) → 蒸気 元素 — 合成確率 78% [████████░░]`.
+- 確率は `SynthesisRecipe::success_probability(is_discovered)` /
+  `SynthesisManager::success_probability_for_recipe(&recipe)` がロジック層で確定し、
+  UI 層は値を整形するだけ。
 
 ## Key Bindings
 

--- a/src/cooldown.rs
+++ b/src/cooldown.rs
@@ -10,6 +10,7 @@
 //! 初回プレイヤーがダッシュボードを開いた瞬間にバーが満タンで表示され、
 //! 「最初の 1 個は当たりが出やすい」という体験を担保する。
 
+use crate::curion::Rarity;
 use chrono::{DateTime, Utc};
 
 /// クールダウン満了までの時間 (時間単位)。
@@ -48,6 +49,73 @@ pub fn remaining_seconds(last_collection_at: Option<DateTime<Utc>>, now: DateTim
             (full_secs - elapsed).max(0)
         }
         None => 0,
+    }
+}
+
+/// Issue #28: 現在のレアリティ別出現確率 (cooldown progress 反映済み)。
+///
+/// `crate::generator::CurionGenerator::generate_with_bonus` の roll-shift モデルに整合する。
+/// roll は `[0.0, 1.0)` の一様分布で、`shifted = (roll - 0.3 * progress).max(0.0)`。
+/// 累積確率は Legendary -> Epic -> Rare -> Common の順 (それぞれの基礎確率は 0.01 / 0.09 / 0.30 / 0.60)。
+///
+/// この関数は実機のサンプリングを介さず、確率密度を直接積分して返す。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RarityProbabilities {
+    pub common: f64,
+    pub rare: f64,
+    pub epic: f64,
+    pub legendary: f64,
+}
+
+impl RarityProbabilities {
+    /// レア以上 (Rare + Epic + Legendary) の合算確率
+    pub fn rare_or_higher(&self) -> f64 {
+        self.rare + self.epic + self.legendary
+    }
+
+    /// レアリティ別確率を順に取り出すイテレータ (UI 用)
+    #[allow(dead_code)]
+    pub fn for_rarity(&self, rarity: Rarity) -> f64 {
+        match rarity {
+            Rarity::Common => self.common,
+            Rarity::Rare => self.rare,
+            Rarity::Epic => self.epic,
+            Rarity::Legendary => self.legendary,
+        }
+    }
+}
+
+/// 現在の cooldown progress を反映したレアリティ別出現確率を返す。
+///
+/// `progress = 0.0` → 基礎確率 (Common 0.60 / Rare 0.30 / Epic 0.09 / Legendary 0.01)。
+/// `progress = 1.0` → 最大シフト (-0.3)。Common 帯が削れ、Legendary 帯が +0.3 シフトの分だけ太る。
+///
+/// 計算は generator.rs の roll-shift モデルから積分で導出:
+/// - P(Legendary) = clamp(0.01 + 0.3 * p, 0, 1)
+/// - P(Epic)      = clamp(0.10 + 0.3 * p, 0, 1) - P(Legendary)
+/// - P(Rare)      = clamp(0.40 + 0.3 * p, 0, 1) - P(Legendary) - P(Epic)
+/// - P(Common)    = 1.0 - その他
+///
+/// 4 値はそれぞれ [0, 1] にクランプされ、総和は 1.0 になる。
+pub fn current_rarity_probabilities(progress: f64) -> RarityProbabilities {
+    let p = progress.clamp(0.0, 1.0);
+    let shift = 0.3 * p;
+
+    // 累積確率の境界 (shift 込み, clamp [0, 1])
+    let cum_legendary = (0.01 + shift).clamp(0.0, 1.0);
+    let cum_epic = (0.10 + shift).clamp(0.0, 1.0);
+    let cum_rare = (0.40 + shift).clamp(0.0, 1.0);
+
+    let legendary = cum_legendary;
+    let epic = (cum_epic - cum_legendary).max(0.0);
+    let rare = (cum_rare - cum_epic).max(0.0);
+    let common = (1.0 - cum_rare).max(0.0);
+
+    RarityProbabilities {
+        common,
+        rare,
+        epic,
+        legendary,
     }
 }
 
@@ -112,6 +180,80 @@ mod tests {
     #[test]
     fn test_rare_multiplier_at_full_is_2() {
         assert!((rare_probability_multiplier(1.0) - 2.0).abs() < 1e-9);
+    }
+
+    // ── Issue #28: current_rarity_probabilities ──────────────────────
+
+    fn sum(p: &RarityProbabilities) -> f64 {
+        p.common + p.rare + p.epic + p.legendary
+    }
+
+    /// progress 0 / 0.5 / 1.0 のいずれでも 4 値の総和は 1.0
+    #[test]
+    fn test_rarity_probabilities_sum_to_one() {
+        for &p in &[0.0_f64, 0.5, 1.0] {
+            let probs = current_rarity_probabilities(p);
+            assert!(
+                (sum(&probs) - 1.0).abs() < 1e-9,
+                "progress={p}: sum={} probs={probs:?}",
+                sum(&probs)
+            );
+        }
+    }
+
+    /// progress=0.0 のとき基礎確率 (60/30/9/1) と一致
+    #[test]
+    fn test_rarity_probabilities_at_zero_matches_base() {
+        let p = current_rarity_probabilities(0.0);
+        assert!((p.common - 0.60).abs() < 1e-9, "common={}", p.common);
+        assert!((p.rare - 0.30).abs() < 1e-9, "rare={}", p.rare);
+        assert!((p.epic - 0.09).abs() < 1e-9, "epic={}", p.epic);
+        assert!(
+            (p.legendary - 0.01).abs() < 1e-9,
+            "legendary={}",
+            p.legendary
+        );
+    }
+
+    /// progress が増えるとレア以上の合算確率は単調増加 (狭義)
+    #[test]
+    fn test_rare_or_higher_increases_with_progress() {
+        let p0 = current_rarity_probabilities(0.0).rare_or_higher();
+        let p_half = current_rarity_probabilities(0.5).rare_or_higher();
+        let p_full = current_rarity_probabilities(1.0).rare_or_higher();
+
+        assert!(p_half > p0, "p_half={p_half} should be > p0={p0}");
+        assert!(
+            p_full > p_half,
+            "p_full={p_full} should be > p_half={p_half}"
+        );
+        // 範囲確認
+        assert!((p0 - 0.40).abs() < 1e-9);
+        assert!(p_full <= 1.0);
+    }
+
+    /// 各値は [0, 1] にクランプされる (progress=1.0 でも負値や 1.0 超は出ない)
+    #[test]
+    fn test_rarity_probabilities_clamp_at_full_progress() {
+        let probs = current_rarity_probabilities(1.0);
+        for v in [probs.common, probs.rare, probs.epic, probs.legendary] {
+            assert!((0.0..=1.0).contains(&v), "value out of range: {v}");
+        }
+        // Legendary 帯は 0.01 + 0.3 = 0.31
+        assert!((probs.legendary - 0.31).abs() < 1e-9);
+        // Common 帯は 0.60 - 0.30 = 0.30
+        assert!((probs.common - 0.30).abs() < 1e-9);
+    }
+
+    /// 範囲外 (負・1超) の progress でも例外なくクランプ動作する
+    #[test]
+    fn test_rarity_probabilities_clamps_out_of_range_progress() {
+        let neg = current_rarity_probabilities(-0.5);
+        let over = current_rarity_probabilities(1.5);
+        let zero = current_rarity_probabilities(0.0);
+        let full = current_rarity_probabilities(1.0);
+        assert_eq!(neg, zero);
+        assert_eq!(over, full);
     }
 
     #[test]

--- a/src/synthesis.rs
+++ b/src/synthesis.rs
@@ -18,6 +18,23 @@ pub struct SynthesisRecipe {
     pub recipe_type: RecipeType,
 }
 
+impl SynthesisRecipe {
+    /// レシピの成功確率を返す (Issue #28)
+    ///
+    /// - `is_discovered == false`: 初見成功率 (`discovery_rate`) をそのまま返す
+    /// - `is_discovered == true`: 100% (1.0) — 発見済みレシピは確定成功
+    ///
+    /// 計算はロジック層に閉じており、UI 層は本メソッドを呼ぶだけで
+    /// 表示用の確率を得られる。
+    pub fn success_probability(&self, is_discovered: bool) -> f64 {
+        if is_discovered {
+            1.0
+        } else {
+            self.discovery_rate.clamp(0.0, 1.0)
+        }
+    }
+}
+
 /// レシピタイプ
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RecipeType {
@@ -331,6 +348,16 @@ impl SynthesisManager {
     pub fn recipe_db(&self) -> &RecipeDatabase {
         &self.recipe_db
     }
+
+    /// 指定レシピの成功確率を返す (Issue #28)
+    ///
+    /// `SynthesisRecipe::success_probability` の薄いラッパー。
+    /// 発見状態を `SynthesisManager` 側で判定して返すので、
+    /// 呼び出し側 (UI) は発見済みかどうかを意識せず確率を取れる。
+    pub fn success_probability_for_recipe(&self, recipe: &SynthesisRecipe) -> f64 {
+        let is_discovered = self.is_discovered(&recipe.id);
+        recipe.success_probability(is_discovered)
+    }
 }
 
 /// 可能な2つ目の材料候補
@@ -398,5 +425,55 @@ mod tests {
             count: 1,
         };
         assert!(!req3.matches(&curion));
+    }
+
+    fn sample_recipe(discovery_rate: f64) -> SynthesisRecipe {
+        SynthesisRecipe {
+            id: "test_recipe".to_string(),
+            name: "テストレシピ".to_string(),
+            description: "for unit test".to_string(),
+            ingredients: vec![],
+            result: SynthesisResult {
+                noun: "結果".to_string(),
+                category: Category::Concept,
+                rarity: Rarity::Rare,
+                synthesis_only: true,
+                special_attributes: HashMap::new(),
+            },
+            discovery_rate,
+            recipe_type: RecipeType::Intuitive,
+        }
+    }
+
+    /// Issue #28: 未発見レシピの成功確率は `discovery_rate` と一致する
+    #[test]
+    fn test_success_probability_undiscovered_matches_discovery_rate() {
+        let recipe = sample_recipe(0.42);
+        assert!((recipe.success_probability(false) - 0.42).abs() < 1e-9);
+    }
+
+    /// Issue #28: 発見済みレシピの成功確率は常に 1.0 (確定成功)
+    #[test]
+    fn test_success_probability_discovered_is_one() {
+        let recipe = sample_recipe(0.10);
+        assert!((recipe.success_probability(true) - 1.0).abs() < 1e-9);
+    }
+
+    /// Issue #28: SynthesisManager 経由でも確率が一貫
+    #[test]
+    fn test_manager_success_probability_for_recipe() {
+        let recipe_db = RecipeDatabase::load_embedded().expect("recipes load");
+        let mut manager = SynthesisManager::new(recipe_db);
+        let recipe_id = manager.recipe_db().all_recipes()[0].id.clone();
+        let recipe = manager.recipe_db().all_recipes()[0].clone();
+
+        // 未発見: discovery_rate と一致
+        let undiscovered_p = manager.success_probability_for_recipe(&recipe);
+        assert!((undiscovered_p - recipe.discovery_rate).abs() < 1e-9);
+
+        // 発見済み: 1.0
+        manager.discover_recipe(recipe_id);
+        let discovered_p = manager.success_probability_for_recipe(&recipe);
+        assert!((discovered_p - 1.0).abs() < 1e-9);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use unicode_width::UnicodeWidthStr;
 use uuid::Uuid;
 
-use crate::cooldown::{cooldown_progress, remaining_seconds};
+use crate::cooldown::{cooldown_progress, current_rarity_probabilities, remaining_seconds};
 use crate::curion::{Category, Curion, Rarity};
 use crate::generator::CurionGenerator;
 use crate::player::{GameState, LoginBonusReward};
@@ -1349,11 +1349,12 @@ impl App {
                 Constraint::Length(3), // 0: GUID timer
                 Constraint::Length(3), // 1: XP gauge
                 Constraint::Length(1), // 2: Rare cooldown
-                Constraint::Length(2), // 3: stats (total/today/level/COMBO)
-                Constraint::Length(1), // 4: next milestone (Issue #32)
-                Constraint::Length(3), // 5: latest curion
-                Constraint::Length(6), // 6: rarity distribution
-                Constraint::Min(4),    // 7: category distribution
+                Constraint::Length(1), // 3: RARE 出現確率 (Issue #28)
+                Constraint::Length(2), // 4: stats (total/today/level/COMBO)
+                Constraint::Length(1), // 5: next milestone (Issue #32)
+                Constraint::Length(3), // 6: latest curion
+                Constraint::Length(6), // 7: rarity distribution
+                Constraint::Min(4),    // 8: category distribution
             ])
             .split(area);
 
@@ -1415,6 +1416,36 @@ impl App {
             .unfilled_style(Style::default().fg(COLOR_LABEL));
         f.render_widget(cooldown_gauge, chunks[2]);
 
+        // Issue #28: 行動前にレア出現確率を表示
+        // 現在の cooldown progress を反映した「現在の」レアリティ別確率を 1 行で出す。
+        // 例: `RARE出現確率: 12.3% (Common 60.0% / Rare 30.0% / Epic 9.0% / Legendary 1.0%)`
+        let rarity_probs = current_rarity_probabilities(cooldown_p);
+        let rare_pct = rarity_probs.rare_or_higher() * 100.0;
+        let rare_probability_line = Line::from(vec![
+            Span::styled("RARE出現確率: ", Style::default().fg(COLOR_LABEL)),
+            Span::styled(
+                format!("{:.1}%", rare_pct),
+                Style::default()
+                    .fg(if cooldown_p >= 1.0 {
+                        COLOR_EPIC
+                    } else {
+                        COLOR_RARE
+                    })
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!(
+                    "  (Common {:.1}% / Rare {:.1}% / Epic {:.1}% / Legendary {:.1}%)",
+                    rarity_probs.common * 100.0,
+                    rarity_probs.rare * 100.0,
+                    rarity_probs.epic * 100.0,
+                    rarity_probs.legendary * 100.0,
+                ),
+                Style::default().fg(COLOR_LABEL),
+            ),
+        ]);
+        f.render_widget(Paragraph::new(rare_probability_line), chunks[3]);
+
         // Basic stats
         let player = &self.game_state.player;
         // COMBO 表示: コンボ中はレアリティ色で強調、5+ は Legendary + 称号アイコン
@@ -1464,7 +1495,7 @@ impl App {
         let stats = Paragraph::new(stats_text)
             .block(unfocused_block("統計"))
             .alignment(Alignment::Left);
-        f.render_widget(stats, chunks[3]);
+        f.render_widget(stats, chunks[4]);
 
         // Issue #32: 次のマイルストーン表示 (= 「あと少し感」を常時演出)
         // XP / 各種実績の残量から最も小さいものを 1 行で出す。
@@ -1489,7 +1520,7 @@ impl App {
             )])
         };
         let milestone_widget = Paragraph::new(vec![milestone_line]).alignment(Alignment::Left);
-        f.render_widget(milestone_widget, chunks[4]);
+        f.render_widget(milestone_widget, chunks[5]);
 
         // Latest curion
         if let Some(curion) = player.latest_curion() {
@@ -1512,7 +1543,7 @@ impl App {
                 ),
             ])];
             let latest = Paragraph::new(latest_text).block(unfocused_block("最新キュリオン"));
-            f.render_widget(latest, chunks[5]);
+            f.render_widget(latest, chunks[6]);
         }
 
         // Rarity distribution
@@ -1543,7 +1574,7 @@ impl App {
             ]));
         }
         let rarity_widget = Paragraph::new(rarity_items).block(unfocused_block("レアリティ分布"));
-        f.render_widget(rarity_widget, chunks[6]);
+        f.render_widget(rarity_widget, chunks[7]);
 
         // Category distribution
         let category_text = ALL_CATEGORIES
@@ -1555,7 +1586,7 @@ impl App {
             .collect::<Vec<_>>()
             .join("  ");
         let category_widget = Paragraph::new(category_text).block(unfocused_block("カテゴリ分布"));
-        f.render_widget(category_widget, chunks[7]);
+        f.render_widget(category_widget, chunks[8]);
     }
 
     fn render_dashboard_bottom(&self, f: &mut Frame<'_>, area: Rect) {
@@ -2644,6 +2675,33 @@ impl App {
                 } else {
                     "???".to_string()
                 };
+
+                // Issue #28: 合成成功確率を LineGauge 風に表示
+                let success_p = self
+                    .game_state
+                    .synthesis_manager
+                    .success_probability_for_recipe(recipe);
+                let success_pct = (success_p * 100.0).round() as u16;
+                let probability_color = if discovered {
+                    COLOR_SUCCESS
+                } else {
+                    COLOR_RARE
+                };
+                let probability_line = Line::from(vec![
+                    Span::raw("    "),
+                    Span::styled("合成確率: ", Style::default().fg(COLOR_LABEL)),
+                    Span::styled(
+                        format!("{success_pct:>3}% "),
+                        Style::default()
+                            .fg(probability_color)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        format!("[{}]", bar(success_p, 10)),
+                        Style::default().fg(probability_color),
+                    ),
+                ]);
+
                 ListItem::new(vec![
                     Line::from(vec![
                         Span::styled(
@@ -2663,6 +2721,7 @@ impl App {
                         ),
                     ]),
                     Line::from(format!("    {} -> {}", recipe.description, preview)),
+                    probability_line,
                     Line::from(""),
                 ])
             })
@@ -2728,13 +2787,32 @@ impl App {
 
                 let discovered_mark = if candidate.is_discovered { "✓" } else { "?" };
 
+                // Issue #28: この候補で実際に通るレシピの成功確率を表示
+                // (first + candidate) が複数レシピにマッチする可能性もあるので、
+                // 「最初にヒットするレシピ」(try_synthesize の挙動と一致) の確率を見せる。
+                let probability_text = self
+                    .first_matching_recipe_for_pair(first_curion, &candidate.noun)
+                    .map(|recipe| {
+                        let p = self
+                            .game_state
+                            .synthesis_manager
+                            .success_probability_for_recipe(recipe);
+                        format!(
+                            " — 合成確率 {:>3}% [{}]",
+                            (p * 100.0).round() as u16,
+                            bar(p, 8)
+                        )
+                    })
+                    .unwrap_or_default();
+
                 ListItem::new(format!(
-                    "{} {} (×{}) {} {}",
+                    "{} {} (×{}) {} {}{}",
                     discovered_mark,
                     candidate.noun,
                     candidate.available_count,
                     result_text,
                     candidate.category.as_str(),
+                    probability_text,
                 ))
                 .style(style)
             })
@@ -2750,6 +2828,32 @@ impl App {
             );
 
         f.render_widget(list, area);
+    }
+
+    /// Issue #28: 1 つ目の材料と 2 つ目候補名詞のペアで最初にマッチするレシピを返す。
+    /// `SynthesisManager::try_synthesize` の挙動 (matching_recipes[0]) と一致する。
+    fn first_matching_recipe_for_pair(
+        &self,
+        first: &crate::curion::Curion,
+        second_noun: &str,
+    ) -> Option<&crate::synthesis::SynthesisRecipe> {
+        // 2 つ目候補のプレースホルダ Curion を作って find_matching_recipes に渡す。
+        // available_count などはチェックされないため、レアリティ/カテゴリは
+        // 「同名詞のうち代表」として collection から拾う。
+        let second_curion = self
+            .game_state
+            .player
+            .collection
+            .iter()
+            .find(|c| c.noun == second_noun)?;
+
+        let ingredients = vec![first.clone(), second_curion.clone()];
+        self.game_state
+            .synthesis_manager
+            .recipe_db()
+            .find_matching_recipes(&ingredients)
+            .into_iter()
+            .next()
     }
 }
 


### PR DESCRIPTION
closes #28

## Summary
- Synthesis レシピ一覧の各レシピに合成確率バーを追加 (未発見=discovery_rate, 発見済み=100%)
- Ingredient 2 候補の末尾に「合成確率 NN% [████████]」を表示
- Dashboard 概要に cooldown 込みの「RARE出現確率: 12.3% (Common ... / Rare ... / Epic ... / Legendary ...)」を 1 行追加
- 確率計算をロジック層に閉じる:
  - `SynthesisRecipe::success_probability(is_discovered)` / `SynthesisManager::success_probability_for_recipe`
  - `cooldown::current_rarity_probabilities(progress) -> RarityProbabilities` (generator の roll-shift モデルと整合)

## Tests
- 追加テスト 8 件 (synthesis 3 件 + cooldown 5 件)
- 全 109 件 pass (101 → 109)
- cargo clippy --all-targets -- -D warnings 通過

## Test plan
- [ ] cargo test --all
- [ ] cargo clippy --all-targets -- -D warnings
- [ ] 実機: Synthesis タブのレシピ一覧で各レシピに合成確率バーが表示されること
- [ ] 実機: Synthesis Phase B で Ingredient 2 候補に確率が付くこと
- [ ] 実機: Dashboard 概要で RARE 出現確率が cooldown progress に応じて変化すること
