### PR TITLE
feat: SAN値パラメータを実装 (#29)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -168,6 +168,12 @@ Right pane layout:
       - cooldown progress 反映済み。レア以上は Cyan+Bold (満タン時は Epic 色)、内訳は Label color
       - 確率は `crate::cooldown::current_rarity_probabilities(progress)` がロジック層で算出
       - generator の roll-shift モデル (累積境界 0.01 / 0.10 / 0.40 + `0.3*progress` シフト) と整合
+    - LineGauge: SAN 値 (正気度) (Issue #29, 1 行)
+      - `SAN [████████░░░░] 67.5 / 100`
+      - 色: >= 80 Cyan / 50..80 Yellow / 30..50 Red / < 30 Magenta + `⚠ 異常状態` ラベル付記
+      - 変動: Common +0.5 / Rare +2.0 / Epic +5.0 / Legendary +15.0 / 合成成功 +3.0 / 時間経過 -0.1/min
+      - 計算は `crate::san` のピュア関数 (`san_gain_for_acquisition` / `apply_decay` / `apply_gain` / `san_state`) に閉じ、UI は値を読んで描画するだけ
+      - 旧セーブ互換: `Player::san` は `#[serde(default = "default_san")]` (= 100.0 で復元)
     - Paragraph: 総獲得数 / 今日の獲得 / レベル / COMBO (one line, inline)
       - COMBO: N — Common でリセット、Rare 以上で +1
       - 表示色: 0/1=Label, 2=Rare, 3-4=Epic, 5+=Legendary + `🔥 コンボマスター!`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,6 +65,7 @@
 - [x] きりの悪い数字設計 (#32) — XP 閾値を非線形テーブル化、実績閾値を割り切れない値にずらし、Dashboard に「next milestone (あと N)」を常時表示
 - [x] 行動前に成功確率を表示する (#28) — Synthesis レシピ一覧と Ingredient 2 候補に「合成確率 NN% [████████░░]」を表示し、Dashboard 概要には cooldown 込みの現在のレアリティ別出現確率を 1 行で表示 (計算は `cooldown::current_rarity_probabilities` / `SynthesisRecipe::success_probability` でロジック層に閉じる)
 - [x] Stats タブ実装 (#26) — レアリティ BarChart (Gray/Cyan/Yellow/Red)、カテゴリ BarChart、時系列タブの直近 30 日 Sparkline。日次集計は `Player::daily_acquisition_counts(days, now)` の純粋関数に閉じてあり、UI 非依存にテスト可能
+- [x] SAN 値パラメータ (#29) — 正気度 (0.0..=100.0) を `Player::san` に追加。Common +0.5 / Rare +2.0 / Epic +5.0 / Legendary +15.0 / 合成成功 +3.0 / 時間経過 -0.1/min。Dashboard 概要に LineGauge を常時表示し、>= 80 Cyan / 50..80 Yellow / 30..50 Red / < 30 Magenta + `⚠ 異常状態` で警告。変動ロジックは `src/san.rs` のピュア関数 (`san_gain_for_acquisition` / `apply_decay` / `apply_gain` / `san_state`) に閉じて UI 非依存
 - [ ] イベントシステム
 - [ ] ランキング
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -155,6 +155,15 @@ Left pane sections:
   - `combo_count` is shown in label color when 0/1, Rare color at 2, Epic color at 3-4, Legendary color + `🔥 コンボマスター!` at 5+
   - `max_combo` is recorded for future stats display
   - Save compatibility: `combo_count` / `max_combo` use `#[serde(default)]`
+- **SAN value (正気度) LineGauge** (Issue #29):
+  - 0.0..=100.0 の `f64` を `Player::san` に持つ。初期値 100.0。
+  - 表示: `SAN [████████░░░░] 67.5 / 100` 形式の LineGauge を常時 1 行で表示。
+  - 色: SAN >= 80 → Cyan / 50..80 → Yellow / 30..50 → Red / < 30 → Magenta + `⚠ 異常状態` ラベル付記。
+  - 変動: Common 収集 +0.5 / Rare +2.0 / Epic +5.0 / Legendary +15.0 / 合成成功 +3.0 /
+    時間経過 -0.1 per minute (放置で減少)。境界は `[0.0, 100.0]` でクランプ。
+  - 変動ロジックは `src/san.rs` のピュア関数 (`san_gain_for_acquisition`,
+    `apply_decay`, `apply_gain`, `san_state`) に閉じ、`ui.rs` は値を読み取って描画するだけ。
+  - Save compatibility: `san` は `#[serde(default = "default_san")]` (= 100.0 で復元)。
 - Latest curion acquired
 - Rarity distribution (horizontal text bars)
 - Category distribution (compact text summary)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod interactive;
 mod nostr_identity;
 mod plain;
 mod player;
+mod san;
 mod save;
 mod synthesis;
 mod ui;

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,6 +1,7 @@
 use crate::achievement::{AchievementManager, AchievementProgress};
 use crate::curion::{Category, Curion, Rarity};
 use crate::daily_mission::{DailyMission, DailyMissionManager};
+use crate::san::{apply_decay, apply_gain, san_gain_for_acquisition, SAN_GAIN_SYNTHESIS, SAN_MAX};
 use crate::synthesis::SynthesisManager;
 use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
@@ -181,6 +182,22 @@ pub struct Player {
     /// 旧セーブには無いため `#[serde(default)]` (= None で復元)。
     #[serde(default)]
     pub last_collection_at: Option<DateTime<Utc>>,
+
+    /// SAN 値 (正気度) (Issue #29)
+    ///
+    /// 0.0〜100.0 の `f64`。初期値 100.0。
+    /// - キュリオン収集 / 合成成功で回復 (`san_gain_for_acquisition`, `SAN_GAIN_SYNTHESIS`)
+    /// - 時間経過で減少 (`SAN_DECAY_PER_MINUTE` per minute)
+    ///
+    /// 旧セーブには無いため `#[serde(default = "default_san")]` (= 100.0 で復元)。
+    #[serde(default = "default_san")]
+    pub san: f64,
+}
+
+/// 旧セーブに `san` フィールドが無い場合のデフォルト値 (Issue #29)。
+/// SAN は初回プレイ時に最大値で始まる仕様。
+fn default_san() -> f64 {
+    SAN_MAX
 }
 
 /// カテゴリ別統計
@@ -274,6 +291,7 @@ impl Player {
             max_combo: 0,
             total_acquisitions: 0,
             last_collection_at: None,
+            san: SAN_MAX,
         }
     }
 
@@ -341,6 +359,9 @@ impl Player {
 
         // Issue #25: 最終収集時刻を更新 (レア出現予告クールダウンをリセット)
         self.last_collection_at = Some(Utc::now());
+
+        // Issue #29: SAN 値をレアリティに応じて回復 (Common +0.5 〜 Legendary +15.0)
+        self.san = apply_gain(self.san, san_gain_for_acquisition(curion.rarity));
 
         // コレクションに追加
         self.collection.push(curion.clone());
@@ -615,8 +636,15 @@ impl Player {
     }
 
     /// プレイ時間を更新（秒）
+    ///
+    /// Issue #29: 経過時間に応じて SAN 値も減少させる。
+    /// 1 分あたり `SAN_DECAY_PER_MINUTE` (= 0.1) ずつ減らし、0 でクランプ。
     pub fn add_play_time(&mut self, seconds: u64) {
         self.total_play_time += seconds;
+
+        // Issue #29: 時間経過による SAN 減少 (放置で減る)
+        let minutes_elapsed = (seconds as f64) / 60.0;
+        self.san = apply_decay(self.san, minutes_elapsed);
     }
 
     /// 称号を追加
@@ -738,12 +766,17 @@ impl GameState {
     }
 
     /// 合成成功を記録し、デイリーミッションの進捗を更新する
+    ///
+    /// Issue #29: SAN 値も `SAN_GAIN_SYNTHESIS` (+3.0) 回復する。
     pub fn record_synthesis_success(&mut self) {
         let today = Local::now().date_naive();
         self.player
             .daily_mission_manager
             .ensure_today_missions(today);
         self.player.daily_mission_manager.record_synthesis_success();
+
+        // Issue #29: SAN 値回復 (合成成功 +3.0)
+        self.player.san = apply_gain(self.player.san, SAN_GAIN_SYNTHESIS);
     }
 
     /// 達成済みのデイリーミッションに自動で報酬 (XP) を付与し、
@@ -1911,6 +1944,170 @@ mod tests {
         assert!(
             buckets.is_empty(),
             "days = 0 のときは空 Vec を返す: {buckets:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #29 SAN 値パラメータ関連のテスト
+    // -----------------------------------------------------------------
+
+    /// テスト用 Curion (Category::Concept 固定、レアリティ可変)。
+    fn san_test_curion(rarity: Rarity) -> Curion {
+        Curion::new(
+            uuid::Uuid::new_v4(),
+            "テスト".to_string(),
+            Category::Concept,
+            rarity,
+            50.0,
+            50.0,
+        )
+    }
+
+    #[test]
+    fn test_san_starts_at_100() {
+        let player = Player::new();
+        assert!(
+            (player.san - 100.0).abs() < 1e-9,
+            "Player::new() の SAN は 100.0 で始まる: {}",
+            player.san
+        );
+    }
+
+    #[test]
+    fn test_san_increases_on_acquisition() {
+        let mut player = Player::new();
+        // SAN を 50.0 に下げてから Common を 1 個拾うと +0.5
+        player.san = 50.0;
+        player.add_curion(san_test_curion(Rarity::Common));
+        assert!(
+            (player.san - 50.5).abs() < 1e-9,
+            "Common +0.5: {}",
+            player.san
+        );
+
+        // 続けて Rare を拾うと +2.0 で 52.5
+        player.add_curion(san_test_curion(Rarity::Rare));
+        assert!(
+            (player.san - 52.5).abs() < 1e-9,
+            "Rare +2.0: {}",
+            player.san
+        );
+
+        // Epic +5.0 で 57.5
+        player.add_curion(san_test_curion(Rarity::Epic));
+        assert!(
+            (player.san - 57.5).abs() < 1e-9,
+            "Epic +5.0: {}",
+            player.san
+        );
+    }
+
+    #[test]
+    fn test_san_increases_more_on_legendary() {
+        let mut player = Player::new();
+        player.san = 50.0;
+        player.add_curion(san_test_curion(Rarity::Common));
+        let after_common = player.san;
+
+        player.san = 50.0;
+        player.add_curion(san_test_curion(Rarity::Legendary));
+        let after_legendary = player.san;
+
+        assert!(
+            after_legendary > after_common,
+            "Legendary 回復量 ({after_legendary}) > Common 回復量 ({after_common})"
+        );
+        // Legendary は +15.0 ぴったり
+        assert!(
+            (after_legendary - 65.0).abs() < 1e-9,
+            "Legendary +15.0: {after_legendary}"
+        );
+    }
+
+    #[test]
+    fn test_san_clamps_at_max_on_acquisition() {
+        // 99.0 + Legendary(+15.0) = 114.0 -> 100.0 にクランプ
+        let mut player = Player::new();
+        player.san = 99.0;
+        player.add_curion(san_test_curion(Rarity::Legendary));
+        assert!(
+            (player.san - 100.0).abs() < 1e-9,
+            "SAN は 100 でクランプ: {}",
+            player.san
+        );
+    }
+
+    #[test]
+    fn test_san_legacy_save_defaults_to_100() {
+        // 旧セーブ JSON (san フィールド無し) を復元したとき
+        // `#[serde(default = "default_san")]` で 100.0 が入る
+        let legacy = json!({
+            "level": 1,
+            "xp": 0,
+            "total_play_time": 0,
+            "first_played_at": "2026-05-14T12:00:00Z",
+            "last_played_at": "2026-05-14T12:00:00Z",
+            "consecutive_login_days": 1,
+            "titles": [],
+            "active_title": null,
+            "today_acquired": 0,
+            "max_daily_acquired": 0,
+            "max_daily_acquired_date": null,
+            "category_stats": {},
+            "rarity_stats": {},
+            "collection": []
+        });
+
+        let player: Player = serde_json::from_value(legacy).unwrap();
+        assert!(
+            (player.san - 100.0).abs() < 1e-9,
+            "legacy save の SAN は 100.0 にデフォルト復元: {}",
+            player.san
+        );
+    }
+
+    #[test]
+    fn test_san_decay_via_add_play_time() {
+        let mut player = Player::new();
+        assert!((player.san - 100.0).abs() < 1e-9);
+
+        // 60 秒 = 1 分 経過 → -0.1
+        player.add_play_time(60);
+        assert!(
+            (player.san - 99.9).abs() < 1e-9,
+            "1 分 → -0.1: {}",
+            player.san
+        );
+
+        // 600 秒 = 10 分経過 → -1.0
+        player.add_play_time(600);
+        assert!(
+            (player.san - 98.9).abs() < 1e-9,
+            "+10 分 → -1.0: {}",
+            player.san
+        );
+
+        // 巨大時間経過でも 0 でクランプ
+        player.add_play_time(60_000_000);
+        assert!(
+            (player.san - 0.0).abs() < 1e-9,
+            "巨大時間経過でも 0 でクランプ: {}",
+            player.san
+        );
+    }
+
+    #[test]
+    fn test_san_increases_on_synthesis_success() {
+        use crate::synthesis::{RecipeDatabase, SynthesisManager};
+
+        let recipe_db = RecipeDatabase::load_embedded().expect("load recipes");
+        let mut state = GameState::new(SynthesisManager::new(recipe_db));
+        state.player.san = 50.0;
+        state.record_synthesis_success();
+        assert!(
+            (state.player.san - 53.0).abs() < 1e-9,
+            "合成成功 +3.0: {}",
+            state.player.san
         );
     }
 }

--- a/src/san.rs
+++ b/src/san.rs
@@ -1,0 +1,159 @@
+//! SAN 値 (正気度) ロジック (Issue #29)
+//!
+//! プレイヤーの「正気度」を 0.0〜100.0 の `f64` で表現する。
+//! キュリオン収集や合成成功で回復し、時間経過で減少する。
+//!
+//! UI 非依存の純粋ロジックに閉じ、ratatui や Player への参照を持たない。
+//! `Player` 側はこの関数群を呼び出して `Player::san` を更新するだけにする。
+
+use crate::curion::Rarity;
+
+/// SAN 値の最大値。
+pub const SAN_MAX: f64 = 100.0;
+/// SAN 値の最小値。
+pub const SAN_MIN: f64 = 0.0;
+/// 合成成功 1 回あたりの SAN 回復量。
+pub const SAN_GAIN_SYNTHESIS: f64 = 3.0;
+/// 時間経過による 1 分あたりの SAN 減少量 (放置で減る)。
+pub const SAN_DECAY_PER_MINUTE: f64 = 0.1;
+
+/// SAN の状態区分 (Dashboard のバー色と警告表示の切り替えに使う)。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SanState {
+    /// >= 80
+    Healthy,
+    /// 50..80
+    Slight,
+    /// 30..50
+    Warning,
+    /// < 30 (「異常状態」表示)
+    Critical,
+}
+
+/// レアリティに応じたキュリオン収集時の SAN 回復量。
+///
+/// - Common: +0.5
+/// - Rare: +2.0
+/// - Epic: +5.0
+/// - Legendary: +15.0
+pub fn san_gain_for_acquisition(rarity: Rarity) -> f64 {
+    match rarity {
+        Rarity::Common => 0.5,
+        Rarity::Rare => 2.0,
+        Rarity::Epic => 5.0,
+        Rarity::Legendary => 15.0,
+    }
+}
+
+/// 時間経過による SAN 減少を適用する。
+///
+/// `minutes_elapsed` 分だけ `SAN_DECAY_PER_MINUTE` を減らし、
+/// `SAN_MIN` (0.0) でクランプする。
+/// 負の `minutes_elapsed` は時間が巻き戻ったケース (clock skew 等)
+/// なので無視 (= 現在値を返す)。
+pub fn apply_decay(current: f64, minutes_elapsed: f64) -> f64 {
+    if minutes_elapsed <= 0.0 {
+        return current.clamp(SAN_MIN, SAN_MAX);
+    }
+    (current - minutes_elapsed * SAN_DECAY_PER_MINUTE).clamp(SAN_MIN, SAN_MAX)
+}
+
+/// SAN 回復を適用する。
+///
+/// `gain` を加算し、`SAN_MAX` (100.0) でクランプする。
+/// 負の `gain` も受け付けるが、その場合は事実上の減少となる
+/// (両端で `[SAN_MIN, SAN_MAX]` にクランプ)。
+pub fn apply_gain(current: f64, gain: f64) -> f64 {
+    (current + gain).clamp(SAN_MIN, SAN_MAX)
+}
+
+/// 現在の SAN 値から状態区分を返す。
+///
+/// 境界値は閾値「以上」で上の区分に入る:
+/// - 100, 80 -> `Healthy`
+/// - 79.99, 50 -> `Slight`
+/// - 49.99, 30 -> `Warning`
+/// - 29.99, 0 -> `Critical`
+pub fn san_state(san: f64) -> SanState {
+    if san >= 80.0 {
+        SanState::Healthy
+    } else if san >= 50.0 {
+        SanState::Slight
+    } else if san >= 30.0 {
+        SanState::Warning
+    } else {
+        SanState::Critical
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPS: f64 = 1e-9;
+
+    #[test]
+    fn test_san_gain_for_acquisition_by_rarity() {
+        assert!((san_gain_for_acquisition(Rarity::Common) - 0.5).abs() < EPS);
+        assert!((san_gain_for_acquisition(Rarity::Rare) - 2.0).abs() < EPS);
+        assert!((san_gain_for_acquisition(Rarity::Epic) - 5.0).abs() < EPS);
+        assert!((san_gain_for_acquisition(Rarity::Legendary) - 15.0).abs() < EPS);
+    }
+
+    #[test]
+    fn test_apply_decay_reduces_san() {
+        // 60 分経過 -> 0.1 * 60 = 6.0 減少
+        let after = apply_decay(100.0, 60.0);
+        assert!((after - 94.0).abs() < EPS, "got {after}");
+
+        // 10 分経過 -> 1.0 減少
+        let after2 = apply_decay(50.0, 10.0);
+        assert!((after2 - 49.0).abs() < EPS, "got {after2}");
+
+        // 0 分または負: 値そのまま (クランプ済み)
+        assert!((apply_decay(50.0, 0.0) - 50.0).abs() < EPS);
+        assert!((apply_decay(50.0, -10.0) - 50.0).abs() < EPS);
+    }
+
+    #[test]
+    fn test_apply_decay_clamps_at_zero() {
+        // 2.0 から 1000 分減少 -> 100 減るが SAN_MIN でクランプ
+        let after = apply_decay(2.0, 1000.0);
+        assert!((after - 0.0).abs() < EPS, "got {after}");
+
+        // すでに 0 でさらに減らしても 0
+        let after2 = apply_decay(0.0, 100.0);
+        assert!((after2 - 0.0).abs() < EPS, "got {after2}");
+    }
+
+    #[test]
+    fn test_apply_gain_clamps_at_max() {
+        // 99.0 + 5.0 = 104.0 -> 100.0 にクランプ
+        let after = apply_gain(99.0, 5.0);
+        assert!((after - SAN_MAX).abs() < EPS, "got {after}");
+
+        // 50.0 + 0.5 = 50.5 (クランプ無し)
+        let after2 = apply_gain(50.0, 0.5);
+        assert!((after2 - 50.5).abs() < EPS, "got {after2}");
+
+        // 100.0 + 15.0 -> 100.0
+        let after3 = apply_gain(100.0, 15.0);
+        assert!((after3 - SAN_MAX).abs() < EPS, "got {after3}");
+    }
+
+    #[test]
+    fn test_san_state_thresholds() {
+        // 100 / 80 は Healthy
+        assert_eq!(san_state(100.0), SanState::Healthy);
+        assert_eq!(san_state(80.0), SanState::Healthy);
+        // 80 直下〜50 は Slight
+        assert_eq!(san_state(79.9999), SanState::Slight);
+        assert_eq!(san_state(50.0), SanState::Slight);
+        // 50 直下〜30 は Warning
+        assert_eq!(san_state(49.9999), SanState::Warning);
+        assert_eq!(san_state(30.0), SanState::Warning);
+        // 30 直下〜0 は Critical
+        assert_eq!(san_state(29.9999), SanState::Critical);
+        assert_eq!(san_state(0.0), SanState::Critical);
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -18,6 +18,7 @@ use crate::cooldown::{cooldown_progress, current_rarity_probabilities, remaining
 use crate::curion::{Category, Curion, Rarity};
 use crate::generator::CurionGenerator;
 use crate::player::{GameState, LoginBonusReward};
+use crate::san::{san_state, SanState, SAN_MAX};
 
 // ── Style constants ──────────────────────────────────────────────
 
@@ -1350,11 +1351,12 @@ impl App {
                 Constraint::Length(3), // 1: XP gauge
                 Constraint::Length(1), // 2: Rare cooldown
                 Constraint::Length(1), // 3: RARE 出現確率 (Issue #28)
-                Constraint::Length(2), // 4: stats (total/today/level/COMBO)
-                Constraint::Length(1), // 5: next milestone (Issue #32)
-                Constraint::Length(3), // 6: latest curion
-                Constraint::Length(6), // 7: rarity distribution
-                Constraint::Min(4),    // 8: category distribution
+                Constraint::Length(1), // 4: SAN bar (Issue #29)
+                Constraint::Length(2), // 5: stats (total/today/level/COMBO)
+                Constraint::Length(1), // 6: next milestone (Issue #32)
+                Constraint::Length(3), // 7: latest curion
+                Constraint::Length(6), // 8: rarity distribution
+                Constraint::Min(4),    // 9: category distribution
             ])
             .split(area);
 
@@ -1446,6 +1448,31 @@ impl App {
         ]);
         f.render_widget(Paragraph::new(rare_probability_line), chunks[3]);
 
+        // Issue #29: SAN 値 (正気度) バー
+        // ロジックは `crate::san` に閉じ、ここでは値を読んで描画するだけ。
+        let san = self.game_state.player.san;
+        let san_ratio = (san / SAN_MAX).clamp(0.0, 1.0);
+        let state = san_state(san);
+        let (san_color, san_warn) = match state {
+            SanState::Healthy => (Color::Cyan, ""),
+            SanState::Slight => (Color::Yellow, ""),
+            SanState::Warning => (Color::Red, ""),
+            SanState::Critical => (Color::Magenta, "  ⚠ 異常状態"),
+        };
+        let san_label = format!(
+            "SAN [{}] {:>5.1} / {:.0}{}",
+            bar(san_ratio, 12),
+            san,
+            SAN_MAX,
+            san_warn
+        );
+        let san_gauge = LineGauge::default()
+            .ratio(san_ratio)
+            .label(san_label)
+            .filled_style(Style::default().fg(san_color))
+            .unfilled_style(Style::default().fg(COLOR_LABEL));
+        f.render_widget(san_gauge, chunks[4]);
+
         // Basic stats
         let player = &self.game_state.player;
         // COMBO 表示: コンボ中はレアリティ色で強調、5+ は Legendary + 称号アイコン
@@ -1495,7 +1522,7 @@ impl App {
         let stats = Paragraph::new(stats_text)
             .block(unfocused_block("統計"))
             .alignment(Alignment::Left);
-        f.render_widget(stats, chunks[4]);
+        f.render_widget(stats, chunks[5]);
 
         // Issue #32: 次のマイルストーン表示 (= 「あと少し感」を常時演出)
         // XP / 各種実績の残量から最も小さいものを 1 行で出す。
@@ -1520,7 +1547,7 @@ impl App {
             )])
         };
         let milestone_widget = Paragraph::new(vec![milestone_line]).alignment(Alignment::Left);
-        f.render_widget(milestone_widget, chunks[5]);
+        f.render_widget(milestone_widget, chunks[6]);
 
         // Latest curion
         if let Some(curion) = player.latest_curion() {
@@ -1543,7 +1570,7 @@ impl App {
                 ),
             ])];
             let latest = Paragraph::new(latest_text).block(unfocused_block("最新キュリオン"));
-            f.render_widget(latest, chunks[6]);
+            f.render_widget(latest, chunks[7]);
         }
 
         // Rarity distribution
@@ -1574,7 +1601,7 @@ impl App {
             ]));
         }
         let rarity_widget = Paragraph::new(rarity_items).block(unfocused_block("レアリティ分布"));
-        f.render_widget(rarity_widget, chunks[7]);
+        f.render_widget(rarity_widget, chunks[8]);
 
         // Category distribution
         let category_text = ALL_CATEGORIES
@@ -1586,7 +1613,7 @@ impl App {
             .collect::<Vec<_>>()
             .join("  ");
         let category_widget = Paragraph::new(category_text).block(unfocused_block("カテゴリ分布"));
-        f.render_widget(category_widget, chunks[8]);
+        f.render_widget(category_widget, chunks[9]);
     }
 
     fn render_dashboard_bottom(&self, f: &mut Frame<'_>, area: Rect) {


### PR DESCRIPTION
closes #29

## Summary

- `Player::san` (f64, 0.0..=100.0, 初期 100.0) を追加
- 変動ロジックは `src/san.rs` のピュア関数に閉じ、`ui.rs` 非依存
  - 収集: Common +0.5 / Rare +2.0 / Epic +5.0 / Legendary +15.0
  - 合成成功: +3.0
  - 時間経過: -0.1 / 分 (放置で減少)
  - 値は [0.0, 100.0] でクランプ
- 変動フック: `Player::add_curion` / `GameState::record_synthesis_success` / `Player::add_play_time`
- Dashboard 概要に SAN LineGauge を常時表示
  - >= 80: Cyan / 50..80: Yellow / 30..50: Red / < 30: Magenta + ⚠ 異常状態
- 旧セーブ互換: `#[serde(default = "default_san")]` で 100.0 復元

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (warnings なし)
- [x] `cargo test --all` で 125 tests pass (113 → 125, +12 新規)
  - `san::tests` 5 本 (gain by rarity / decay / decay clamp / gain clamp / state thresholds)
  - `player::tests` 7 本 (starts 100 / increases on acquisition / legendary > common / clamp on acquisition / legacy save default / decay via add_play_time / synthesis success +3.0)
- [ ] TUI で Dashboard 概要を目視確認 (色変化・異常状態表示・放置減少)