### PR TITLE
feat: 寿命システムを実装 (#30)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -430,6 +430,34 @@ Behaviour:
     without applying any filter and without crashing.
 ```
 
+### Lifespan System (Issue #30) — IMPLEMENTED
+
+```
+レアリティ別に有限寿命を持たせ、放置されたキュリオンを「自然消滅」させる。
+合成消費は寿命を見ない (使ってあげる = 供養)。
+
+寿命日数:
+  - Common: 3 日 / Rare: 7 日 / Epic: 14 日 / Legendary: 30 日
+
+Curion field:
+  - `lifespan_days: Option<u32>` (新規 = Some, 旧セーブ = None で永遠)
+
+Pruning:
+  - 起動時 (`process_login` 直後) に `prune_expired_curions(now)` を呼ぶ
+  - 削除分は TUI トースト / --plain セクション / interactive REPL 出力で通知
+  - 6 秒トースト (通常 3 秒より長め、見逃さないように)
+
+Dashboard Overview 表示:
+  - "⚠ 期限切れ間近 (残り 1 日以下): N 個" を 1 行で警告 (0 個なら空行)
+
+Collection Owned List 表示:
+  - 各行右端に残り寿命: `残 N 日`
+  - 残 ≤ 0: 赤 + `寿命: ! まもなく消滅`
+  - 残 ≤ 3: 黄色
+  - それ以上: 薄いグレー
+  - 寿命なし: `寿命: --`
+```
+
 ### High-risk Synthesis (Issue #35)
 
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,6 +66,7 @@
 - [x] 行動前に成功確率を表示する (#28) — Synthesis レシピ一覧と Ingredient 2 候補に「合成確率 NN% [████████░░]」を表示し、Dashboard 概要には cooldown 込みの現在のレアリティ別出現確率を 1 行で表示 (計算は `cooldown::current_rarity_probabilities` / `SynthesisRecipe::success_probability` でロジック層に閉じる)
 - [x] Stats タブ実装 (#26) — レアリティ BarChart (Gray/Cyan/Yellow/Red)、カテゴリ BarChart、時系列タブの直近 30 日 Sparkline。日次集計は `Player::daily_acquisition_counts(days, now)` の純粋関数に閉じてあり、UI 非依存にテスト可能
 - [x] SAN 値パラメータ (#29) — 正気度 (0.0..=100.0) を `Player::san` に追加。Common +0.5 / Rare +2.0 / Epic +5.0 / Legendary +15.0 / 合成成功 +3.0 / 時間経過 -0.1/min。Dashboard 概要に LineGauge を常時表示し、>= 80 Cyan / 50..80 Yellow / 30..50 Red / < 30 Magenta + `⚠ 異常状態` で警告。変動ロジックは `src/san.rs` のピュア関数 (`san_gain_for_acquisition` / `apply_decay` / `apply_gain` / `san_state`) に閉じて UI 非依存
+- [x] 寿命システム (#30) — レアリティ別寿命 (Common 3 / Rare 7 / Epic 14 / Legendary 30 日) を `Curion::lifespan_days: Option<u32>` で保持し、起動時に `Player::prune_expired` で期限切れキュリオンを自動削除。削除分は TUI トースト (6 秒) / --plain / interactive モードで通知。Collection 一覧の各行に残り寿命を表示 (残 ≤ 0 = 赤、≤ 3 = 黄、それ以上 = グレー、寿命なし = `--`)。Dashboard 概要に「⚠ 期限切れ間近 (残り 1 日以下): N 個」を常時表示 (0 個なら空行)。合成消費は寿命を見ず「使ってあげること = 供養」として扱う。旧セーブは `lifespan_days = None` で復元され永遠扱い (後方互換)
 - [ ] イベントシステム
 - [ ] ランキング
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -46,6 +46,47 @@ Combine two owned curions to create a new one.
 - Smart synthesis UI suggests valid combinations from the player's inventory.
 - Discovered recipes are tracked and shown in the UI.
 
+## Lifespan System (Issue #30)
+
+Each curion has a finite lifespan tied to its rarity. Curions left in the
+collection past their lifespan are auto-removed at the next launch (treated
+as natural decay). Synthesizing a curion does **not** count as natural decay
+— "using it up" is its proper send-off.
+
+| Rarity | Lifespan |
+|---|---|
+| Common | 3 days |
+| Rare | 7 days |
+| Epic | 14 days |
+| Legendary | 30 days |
+
+- `Curion::lifespan_days: Option<u32>` is set at acquisition time via
+  `lifespan_for_rarity(rarity)` in `src/curion.rs`. New curions always carry
+  `Some(...)`; legacy saves without the field deserialize to `None` (immortal)
+  for backward compatibility.
+- `Curion::expires_at()` = `acquired_at + lifespan_days`. Returns `None`
+  for immortal curions.
+- `Curion::is_expired(now)` = `now > expires_at()`. Always `false` for
+  immortal curions.
+- `Curion::days_remaining(now)` returns `(expires_at - now).num_days()`.
+  Negative values mean already-expired.
+- `Player::prune_expired(now) -> Vec<Curion>` removes expired curions from
+  the collection and returns the removed list. Stats (`rarity_stats`,
+  `category_stats`) are intentionally left untouched — they are cumulative
+  acquisition histories, not current-inventory views.
+- `GameState::prune_expired_curions(now)` delegates to the player and is
+  invoked right after `process_login()` in `main.rs`, `plain.rs`, and
+  `interactive.rs`. The returned list drives:
+  - TUI: `App::show_expired_curions_message` toast (6-second display)
+  - `--plain` mode: a `=== 寿命で消えたキュリオン (N 個) ===` section
+  - Interactive (REPL) mode: a yellow-titled list
+- Dashboard Overview shows `⚠ 期限切れ間近 (残り 1 日以下): N 個` while at
+  least one curion is one day from expiring; otherwise the row is blank but
+  still occupies one terminal line for layout stability.
+- Synthesis consumes ingredients via the existing inventory removal path
+  and does not interact with lifespan — using a curion for synthesis simply
+  retires it before natural decay can occur.
+
 ## Achievement System
 
 40+ achievements across 4 categories:
@@ -164,6 +205,9 @@ Left pane sections:
   - 変動ロジックは `src/san.rs` のピュア関数 (`san_gain_for_acquisition`,
     `apply_decay`, `apply_gain`, `san_state`) に閉じ、`ui.rs` は値を読み取って描画するだけ。
   - Save compatibility: `san` は `#[serde(default = "default_san")]` (= 100.0 で復元)。
+- **Lifespan warning** (Issue #30):
+  - 残り寿命 1 日以下のキュリオン数を 1 行で表示: `⚠ 期限切れ間近 (残り 1 日以下): N 個`
+  - 0 個のときは空行扱い (レイアウトは予約)
 - Latest curion acquired
 - Rarity distribution (horizontal text bars)
 - Category distribution (compact text summary)
@@ -216,7 +260,11 @@ Left pane sections:
 
 **Owned List right pane:**
 - Scrollable list of all owned curions
-- Display format: `#ID stars [Rarity] Category Name  Date`
+- Display format: `#ID stars [Rarity] Category Name  Date  残 N 日` (Issue #30 残り寿命を右端に追記)
+  - 残り 0 日以下: 赤 + `寿命: ! まもなく消滅`
+  - 残り 1〜3 日: 黄色 `残 N 日`
+  - それ以上: 薄いグレー `残 N 日`
+  - 寿命なし (旧セーブ): `寿命: --`
 - Attribute bars (interest, beauty) shown inline
 - Bottom detail pane (`Constraint::Length(4)`, Issue #22 + #27): two lines for the curion currently at the top of the visible list. Wraps if the flavor exceeds the line width.
   - Line 1: SF flavor text (Issue #22). Missing flavor falls back to `(フレーバー未登録)`.

--- a/src/curion.rs
+++ b/src/curion.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -53,6 +53,25 @@ impl Category {
     }
 }
 
+/// レアリティ別の寿命日数 (Issue #30)
+///
+/// 各キュリオンは入手時にレアリティに応じた寿命日数を持つ。
+/// 期限切れになると起動時に自動削除される (合成で消費されたものは
+/// 「使ってあげた = 供養」として自然消滅にカウントしない)。
+///
+/// - Common: 3 日
+/// - Rare: 7 日
+/// - Epic: 14 日
+/// - Legendary: 30 日
+pub fn lifespan_for_rarity(rarity: Rarity) -> u32 {
+    match rarity {
+        Rarity::Common => 3,
+        Rarity::Rare => 7,
+        Rarity::Epic => 14,
+        Rarity::Legendary => 30,
+    }
+}
+
 /// キュリオン（興味を司る粒子）
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Curion {
@@ -87,6 +106,19 @@ pub struct Curion {
     /// deserialize 時は `None` になる。`None` の場合 UI 側で「履歴情報なし」と表示する。
     #[serde(default)]
     pub acquisition_index: Option<u32>,
+
+    /// 寿命日数 (Issue #30)
+    ///
+    /// 入手時に `lifespan_for_rarity(rarity)` で設定される (Common 3 / Rare 7 /
+    /// Epic 14 / Legendary 30 日)。`acquired_at + lifespan_days` を過ぎた
+    /// キュリオンは起動時に自動削除される。
+    ///
+    /// `None` は「寿命なし (永遠)」を意味し、フィールドを持たない旧セーブからの
+    /// deserialize 時のみ `None` になる。新規生成では必ず `Some(...)` が入る。
+    /// 旧セーブのキュリオンは消えずに残り続け、Collection 一覧では残り寿命を
+    /// `--` として表示する。
+    #[serde(default)]
+    pub lifespan_days: Option<u32>,
 }
 
 impl Curion {
@@ -109,12 +141,38 @@ impl Curion {
             beauty,
             acquired_at: Utc::now(),
             acquisition_index: None,
+            lifespan_days: Some(lifespan_for_rarity(rarity)),
         }
     }
 
     /// キュリオンの表示用文字列
     pub fn display_name(&self) -> String {
         format!("{} の {}", self.category.as_str(), self.noun)
+    }
+
+    /// 寿命の終了予定時刻 (Issue #30)
+    ///
+    /// `acquired_at + lifespan_days`。`lifespan_days = None` の場合は `None`
+    /// (= 永遠、旧セーブ互換)。
+    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
+        self.lifespan_days
+            .map(|d| self.acquired_at + Duration::days(d as i64))
+    }
+
+    /// 期限切れかどうか (Issue #30)
+    ///
+    /// `now > expires_at()` のときに `true`。寿命のないキュリオン
+    /// (`lifespan_days = None`) は常に `false`。
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        self.expires_at().map(|e| now > e).unwrap_or(false)
+    }
+
+    /// 残り寿命 (日数、Issue #30)
+    ///
+    /// `expires_at - now` を日数で返す。負の値 (期限切れ) もそのまま返す。
+    /// 寿命のないキュリオン (`lifespan_days = None`) は `None`。
+    pub fn days_remaining(&self, now: DateTime<Utc>) -> Option<i64> {
+        self.expires_at().map(|e| (e - now).num_days())
     }
 
     /// Collection 詳細ペイン用の入手履歴行 (Issue #27)
@@ -135,5 +193,82 @@ impl Curion {
             Some(idx) => format!("入手: {local_time}  (通算 {idx}回目の収集)"),
             None => format!("入手: {local_time}  (履歴情報なし)"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    /// Issue #30: レアリティ別寿命の数値 (Common 3 / Rare 7 / Epic 14 / Legendary 30)。
+    #[test]
+    fn test_lifespan_for_rarity() {
+        assert_eq!(lifespan_for_rarity(Rarity::Common), 3);
+        assert_eq!(lifespan_for_rarity(Rarity::Rare), 7);
+        assert_eq!(lifespan_for_rarity(Rarity::Epic), 14);
+        assert_eq!(lifespan_for_rarity(Rarity::Legendary), 30);
+    }
+
+    fn make_curion_at(rarity: Rarity, acquired_at: DateTime<Utc>) -> Curion {
+        let mut c = Curion::new(
+            Uuid::new_v4(),
+            "テスト".to_string(),
+            Category::Animal,
+            rarity,
+            0.5,
+            0.5,
+        );
+        c.acquired_at = acquired_at;
+        c
+    }
+
+    /// Issue #30: `expires_at()` は `acquired_at + lifespan_days` を返す。
+    #[test]
+    fn test_expires_at_basic() {
+        let acquired = Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap();
+        let c = make_curion_at(Rarity::Rare, acquired); // 7 日寿命
+        let expected = acquired + Duration::days(7);
+        assert_eq!(c.expires_at(), Some(expected));
+    }
+
+    /// Issue #30: `expires_at` を過ぎた `now` で `is_expired = true`。
+    #[test]
+    fn test_is_expired_true_after_lifespan() {
+        let acquired = Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap();
+        let c = make_curion_at(Rarity::Common, acquired); // 3 日寿命
+        let now = acquired + Duration::days(3) + Duration::seconds(1);
+        assert!(c.is_expired(now));
+    }
+
+    /// Issue #30: 寿命内では `is_expired = false`。
+    #[test]
+    fn test_is_expired_false_within_lifespan() {
+        let acquired = Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap();
+        let c = make_curion_at(Rarity::Epic, acquired); // 14 日寿命
+        let now = acquired + Duration::days(13);
+        assert!(!c.is_expired(now));
+    }
+
+    /// Issue #30: `days_remaining` は `(expires_at - now).num_days()` を返す。
+    #[test]
+    fn test_days_remaining_basic() {
+        let acquired = Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap();
+        let c = make_curion_at(Rarity::Legendary, acquired); // 30 日寿命
+        let now = acquired + Duration::days(5);
+        assert_eq!(c.days_remaining(now), Some(25));
+    }
+
+    /// Issue #30: `lifespan_days = None` (旧セーブ等) は永遠扱いで期限切れにならない。
+    #[test]
+    fn test_is_expired_none_when_no_lifespan() {
+        let acquired = Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap();
+        let mut c = make_curion_at(Rarity::Common, acquired);
+        c.lifespan_days = None;
+        // どれだけ未来でも期限切れにならない
+        let far_future = acquired + Duration::days(10_000);
+        assert!(!c.is_expired(far_future));
+        assert_eq!(c.expires_at(), None);
+        assert_eq!(c.days_remaining(far_future), None);
     }
 }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -190,6 +190,8 @@ pub fn run_interactive_mode(profile_manager: &ProfileManager) -> Result<()> {
 
     // ログイン処理
     let login_bonus = game_state.process_login();
+    // Issue #30: 期限切れキュリオンを削除して通知する。
+    let expired = game_state.prune_expired_curions(chrono::Utc::now());
     save_manager.save(&game_state)?;
 
     let mut helper = CurionHelper::new();
@@ -216,6 +218,18 @@ pub fn run_interactive_mode(profile_manager: &ProfileManager) -> Result<()> {
         println!("\x1b[1;32mLogin Bonus\x1b[0m");
         for line in reward.summary_lines() {
             println!("  {line}");
+        }
+        println!();
+    }
+
+    // Issue #30: 期限切れで消えたキュリオンを通知
+    if !expired.is_empty() {
+        println!(
+            "\x1b[1;33m寿命で消えたキュリオン ({} 個)\x1b[0m",
+            expired.len()
+        );
+        for c in &expired {
+            println!("  - {}", c.display_name());
         }
         println!();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,8 @@ pub fn run_tui(profile_manager: &ProfileManager) -> Result<()> {
     let save_manager = SaveManager::new_with_profile(profile_manager)?;
     let mut game_state = save_manager.load()?;
     let login_bonus = game_state.process_login();
+    // Issue #30: 起動時に期限切れキュリオンを自動削除し、UI に通知メッセージを残す。
+    let expired = game_state.prune_expired_curions(chrono::Utc::now());
     save_manager.save(&game_state)?;
 
     // Terminal setup
@@ -94,6 +96,10 @@ pub fn run_tui(profile_manager: &ProfileManager) -> Result<()> {
     app.flush_daily_mission_rewards();
     if let Some(reward) = login_bonus {
         app.show_login_bonus_message(&reward);
+    }
+    // Issue #30: 期限切れで削除されたキュリオンを 1 行トーストで知らせる。
+    if !expired.is_empty() {
+        app.show_expired_curions_message(&expired);
     }
 
     let res = run_app(&mut terminal, &mut app, &save_manager);

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -22,6 +22,8 @@ pub fn run_plain_mode(profile_manager: &ProfileManager, args: &[String]) -> Resu
     let save_manager = SaveManager::new_with_profile(profile_manager)?;
     let mut game_state = save_manager.load()?;
     let login_bonus = game_state.process_login();
+    // Issue #30: 期限切れキュリオンを起動時に削除し、ユーザーに通知する。
+    let expired = game_state.prune_expired_curions(chrono::Utc::now());
     save_manager.save(&game_state)?;
     let generator = CurionGenerator::new()?;
 
@@ -29,6 +31,14 @@ pub fn run_plain_mode(profile_manager: &ProfileManager, args: &[String]) -> Resu
         println!("=== Login Bonus ===");
         for line in reward.summary_lines() {
             println!("  {line}");
+        }
+        println!();
+    }
+
+    if !expired.is_empty() {
+        println!("=== 寿命で消えたキュリオン ({} 個) ===", expired.len());
+        for c in &expired {
+            println!("  - [{}] {}", rarity_tag(c.rarity), c.display_name());
         }
         println!();
     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -654,6 +654,27 @@ impl Player {
         }
     }
 
+    /// 期限切れキュリオンを collection から取り除き、削除した一覧を返す (Issue #30)。
+    ///
+    /// `Curion::is_expired(now)` が true のものを除外する。
+    /// `lifespan_days = None` (旧セーブ等の永遠キュリオン) は対象外。
+    /// 統計 (`rarity_stats` / `category_stats`) は触らない — これらは
+    /// 「過去に何個入手したか」を表す累積カウンタとして扱い、自然消滅で
+    /// 履歴を消さない方針。
+    pub fn prune_expired(&mut self, now: DateTime<Utc>) -> Vec<Curion> {
+        let mut removed = Vec::new();
+        let mut kept = Vec::with_capacity(self.collection.len());
+        for c in self.collection.drain(..) {
+            if c.is_expired(now) {
+                removed.push(c);
+            } else {
+                kept.push(c);
+            }
+        }
+        self.collection = kept;
+        removed
+    }
+
     /// 最新のキュリオンを取得
     pub fn latest_curion(&self) -> Option<&Curion> {
         self.collection.last()
@@ -744,6 +765,15 @@ impl GameState {
             .ensure_today_missions(today);
         self.refresh_achievement_progress();
         reward
+    }
+
+    /// 期限切れキュリオンを起動時に削除する (Issue #30)。
+    ///
+    /// `process_login` の後に呼び出して、UI 側で削除されたキュリオンの
+    /// 通知 (トースト等) に使うことを想定している。実績/ミッション進捗には
+    /// 影響を与えない (削除は履歴 = `rarity_stats` 等に残す)。
+    pub fn prune_expired_curions(&mut self, now: DateTime<Utc>) -> Vec<Curion> {
+        self.player.prune_expired(now)
     }
 
     /// キュリオンを追加し、実績とデイリーミッションを更新する。
@@ -2109,5 +2139,109 @@ mod tests {
             "合成成功 +3.0: {}",
             state.player.san
         );
+    }
+
+    // -------------------------------------------------------------------
+    // Issue #30 寿命システム (Player::prune_expired)
+    // -------------------------------------------------------------------
+
+    fn make_curion_with_lifespan(
+        rarity: Rarity,
+        acquired_at: DateTime<Utc>,
+        lifespan_days: Option<u32>,
+    ) -> Curion {
+        let mut c = Curion::new(
+            uuid::Uuid::new_v4(),
+            "テスト".to_string(),
+            Category::Animal,
+            rarity,
+            0.5,
+            0.5,
+        );
+        c.acquired_at = acquired_at;
+        c.lifespan_days = lifespan_days;
+        c
+    }
+
+    /// Issue #30: prune_expired は期限切れだけを除外し、寿命内のキュリオンは残す。
+    #[test]
+    fn test_prune_expired_removes_expired_only() {
+        let mut player = Player::new();
+        let acquired = dt(2026, 5, 1);
+        // 期限切れ (Common 3 日寿命、5 日経過)
+        let expired = make_curion_with_lifespan(Rarity::Common, acquired, Some(3));
+        // 寿命内 (Legendary 30 日寿命)
+        let alive = make_curion_with_lifespan(Rarity::Legendary, acquired, Some(30));
+        player.collection.push(expired);
+        player.collection.push(alive);
+
+        let now = acquired + Duration::days(5);
+        let removed = player.prune_expired(now);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].rarity, Rarity::Common);
+        assert_eq!(player.collection.len(), 1);
+        assert_eq!(player.collection[0].rarity, Rarity::Legendary);
+    }
+
+    /// Issue #30: prune_expired は削除したキュリオンを Vec で返す (順序は元の collection 順)。
+    #[test]
+    fn test_prune_expired_returns_removed_curions() {
+        let mut player = Player::new();
+        let acquired = dt(2026, 5, 1);
+        let c1 = make_curion_with_lifespan(Rarity::Common, acquired, Some(3));
+        let c2 = make_curion_with_lifespan(Rarity::Rare, acquired, Some(7));
+        let c3 = make_curion_with_lifespan(Rarity::Epic, acquired, Some(14));
+        player.collection.push(c1);
+        player.collection.push(c2);
+        player.collection.push(c3);
+
+        // 8 日経過: Common (3 日) と Rare (7 日) が期限切れ、Epic は残る
+        let now = acquired + Duration::days(8);
+        let removed = player.prune_expired(now);
+        assert_eq!(removed.len(), 2);
+        assert_eq!(removed[0].rarity, Rarity::Common);
+        assert_eq!(removed[1].rarity, Rarity::Rare);
+        assert_eq!(player.collection.len(), 1);
+        assert_eq!(player.collection[0].rarity, Rarity::Epic);
+    }
+
+    /// Issue #30: lifespan_days = None の旧セーブ由来キュリオンは絶対に削除しない。
+    #[test]
+    fn test_prune_expired_keeps_curions_without_lifespan() {
+        let mut player = Player::new();
+        let acquired = dt(2020, 1, 1);
+        // 寿命なし (旧セーブ互換)
+        let eternal = make_curion_with_lifespan(Rarity::Common, acquired, None);
+        player.collection.push(eternal);
+
+        let now = dt(2026, 5, 1); // 6 年経過
+        let removed = player.prune_expired(now);
+        assert!(removed.is_empty());
+        assert_eq!(player.collection.len(), 1);
+        assert!(player.collection[0].lifespan_days.is_none());
+    }
+
+    /// Issue #30: 旧セーブ JSON (lifespan_days フィールド無し) からの deserialize で
+    /// `lifespan_days = None` に復元され、期限切れ扱いされない。
+    #[test]
+    fn test_legacy_save_curion_without_lifespan_loads() {
+        let legacy_json = json!({
+            "id": "11111111-1111-4111-9111-111111111111",
+            "source_guid": "22222222-2222-4222-9222-222222222222",
+            "noun": "テスト",
+            "category": "Animal",
+            "rarity": "Common",
+            "interest": 0.5,
+            "beauty": 0.5,
+            "acquired_at": "2020-01-01T00:00:00Z"
+        });
+        let curion: Curion =
+            serde_json::from_value(legacy_json).expect("legacy Curion should deserialize");
+        assert!(
+            curion.lifespan_days.is_none(),
+            "旧セーブの lifespan_days は None でロードされる"
+        );
+        assert!(curion.expires_at().is_none());
+        assert!(!curion.is_expired(dt(2026, 5, 1)));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -122,6 +122,24 @@ fn rarity_label(rarity: &Rarity) -> &'static str {
     }
 }
 
+/// 残り寿命を表す Span を返す (Issue #30)。
+///
+/// - 残り 0 日以下: 赤 + `!` 警告アイコン (まもなく消滅)
+/// - 残り 1〜3 日: 黄色
+/// - それ以上: 薄いグレー
+/// - 寿命なし (`lifespan_days = None`、旧セーブ): `--`
+pub(crate) fn lifespan_span_for(curion: &Curion, now: chrono::DateTime<chrono::Utc>) -> Span<'_> {
+    match curion.days_remaining(now) {
+        None => Span::styled("寿命: --", Style::default().fg(Color::DarkGray)),
+        Some(d) if d <= 0 => Span::styled(
+            "寿命: ! まもなく消滅".to_string(),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ),
+        Some(d) if d <= 3 => Span::styled(format!("残 {d} 日"), Style::default().fg(Color::Yellow)),
+        Some(d) => Span::styled(format!("残 {d} 日"), Style::default().fg(Color::DarkGray)),
+    }
+}
+
 /// Issue #31: 正規表現フィルタの長尺レアリティラベル。
 ///
 /// `rarity_label` は `[COM ]` 等の固定 4 桁表示用に短縮されているため、ユーザーが
@@ -716,6 +734,28 @@ impl App {
             format!("🎁 Day {} +{} XP", reward.day, reward.xp),
             Instant::now(),
         ));
+    }
+
+    /// 期限切れで消えたキュリオンを 1 行トーストで表示する (Issue #30)。
+    ///
+    /// 表示時間は通常より長めの 6 秒に延長する (普段見ない情報なので拾わせる)。
+    pub fn show_expired_curions_message(&mut self, expired: &[Curion]) {
+        if expired.is_empty() {
+            return;
+        }
+        let preview: String = expired
+            .iter()
+            .take(3)
+            .map(|c| c.display_name())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let more = if expired.len() > 3 {
+            format!(" 他 {} 個", expired.len() - 3)
+        } else {
+            String::new()
+        };
+        self.save_message_duration = Duration::from_secs(6);
+        self.save_message = Some((format!("🕯 寿命で消滅: {}{}", preview, more), Instant::now()));
     }
 
     fn guid_progress(&self) -> f64 {
@@ -1354,9 +1394,10 @@ impl App {
                 Constraint::Length(1), // 4: SAN bar (Issue #29)
                 Constraint::Length(2), // 5: stats (total/today/level/COMBO)
                 Constraint::Length(1), // 6: next milestone (Issue #32)
-                Constraint::Length(3), // 7: latest curion
-                Constraint::Length(6), // 8: rarity distribution
-                Constraint::Min(4),    // 9: category distribution
+                Constraint::Length(1), // 7: lifespan warning (Issue #30)
+                Constraint::Length(3), // 8: latest curion
+                Constraint::Length(6), // 9: rarity distribution
+                Constraint::Min(4),    // 10: category distribution
             ])
             .split(area);
 
@@ -1549,6 +1590,34 @@ impl App {
         let milestone_widget = Paragraph::new(vec![milestone_line]).alignment(Alignment::Left);
         f.render_widget(milestone_widget, chunks[6]);
 
+        // Issue #30: 期限切れ間近 (残り 1 日以下) のキュリオン数を 1 行で警告。
+        // 0 個のときも空行として描画して、レイアウト的に予約だけ残す
+        // (Length(1) を消費しないと下のチャンクが詰まって見えなくなるため)。
+        let now_utc = chrono::Utc::now();
+        let near_expiry_count = player
+            .collection
+            .iter()
+            .filter(|c| match c.days_remaining(now_utc) {
+                Some(d) => d <= 1,
+                None => false,
+            })
+            .count();
+        let lifespan_line = if near_expiry_count > 0 {
+            Line::from(vec![
+                Span::styled(
+                    "⚠ 期限切れ間近 (残り 1 日以下): ",
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(
+                    format!("{} 個", near_expiry_count),
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                ),
+            ])
+        } else {
+            Line::from("")
+        };
+        f.render_widget(Paragraph::new(lifespan_line), chunks[7]);
+
         // Latest curion
         if let Some(curion) = player.latest_curion() {
             let color = rarity_color(&curion.rarity);
@@ -1570,7 +1639,7 @@ impl App {
                 ),
             ])];
             let latest = Paragraph::new(latest_text).block(unfocused_block("最新キュリオン"));
-            f.render_widget(latest, chunks[7]);
+            f.render_widget(latest, chunks[8]);
         }
 
         // Rarity distribution
@@ -1601,7 +1670,7 @@ impl App {
             ]));
         }
         let rarity_widget = Paragraph::new(rarity_items).block(unfocused_block("レアリティ分布"));
-        f.render_widget(rarity_widget, chunks[8]);
+        f.render_widget(rarity_widget, chunks[9]);
 
         // Category distribution
         let category_text = ALL_CATEGORIES
@@ -1613,7 +1682,7 @@ impl App {
             .collect::<Vec<_>>()
             .join("  ");
         let category_widget = Paragraph::new(category_text).block(unfocused_block("カテゴリ分布"));
-        f.render_widget(category_widget, chunks[9]);
+        f.render_widget(category_widget, chunks[10]);
     }
 
     fn render_dashboard_bottom(&self, f: &mut Frame<'_>, area: Rect) {
@@ -1783,6 +1852,7 @@ impl App {
             format!("コレクション [{} 個]", collection.len())
         };
 
+        let now_utc = chrono::Utc::now();
         let items: Vec<ListItem> = filtered
             .iter()
             .rev()
@@ -1795,6 +1865,10 @@ impl App {
                 let stars = rarity_stars(&curion.rarity);
                 let label = rarity_label(&curion.rarity);
                 let index = filtered.len() - i;
+
+                // Issue #30: 残り寿命を 1 行右側に表示。1 日以下で Red、3 日以下で
+                // Yellow、それ以上は薄いグレー。寿命なし (旧セーブ) は `--`。
+                let lifespan_span = lifespan_span_for(curion, now_utc);
 
                 ListItem::new(vec![
                     Line::from(vec![
@@ -1814,6 +1888,8 @@ impl App {
                             curion.acquired_at.format("%Y-%m-%d %H:%M").to_string(),
                             Style::default().fg(Color::DarkGray),
                         ),
+                        Span::raw("  "),
+                        lifespan_span,
                     ]),
                     Line::from(vec![
                         Span::raw("      興味度: "),


### PR DESCRIPTION
closes #30

## Summary

- 各 Curion に「寿命 (日数)」を入手時に付与 (Common 3 / Rare 7 / Epic 14 / Legendary 30 日)
- 起動時に期限切れキュリオンを自動削除し、TUI / --plain / interactive モードで通知
- Collection 一覧に残り寿命を表示 (≤0 赤 + 警告、≤3 黄、それ以上 グレー、寿命なし `--`)
- Dashboard 概要に「⚠ 期限切れ間近 (残り 1 日以下): N 個」を 1 行警告
- 合成消費は寿命を見ない (使ってあげること = 供養)
- 旧セーブ互換: `lifespan_days: Option<u32>` が `None` の場合は永遠扱い

## 実装の構造

- `Curion::lifespan_days: Option<u32>` (`#[serde(default)]` で旧セーブ互換)
- `Curion::{expires_at, is_expired, days_remaining}` メソッド
- `lifespan_for_rarity(rarity) -> u32` 自由関数
- `Player::prune_expired(now: DateTime<Utc>) -> Vec<Curion>` で削除
- `GameState::prune_expired_curions(now)` を `process_login()` 直後に呼ぶ
- 統計 (`rarity_stats` / `category_stats`) は自然消滅で減らさない (累積履歴扱い)

## テスト

10 件追加 (合計 125 → 135):

- curion: `test_lifespan_for_rarity`, `test_expires_at_basic`, `test_is_expired_true_after_lifespan`, `test_is_expired_false_within_lifespan`, `test_days_remaining_basic`, `test_is_expired_none_when_no_lifespan`
- player: `test_prune_expired_removes_expired_only`, `test_prune_expired_returns_removed_curions`, `test_prune_expired_keeps_curions_without_lifespan`, `test_legacy_save_curion_without_lifespan_loads`

## Test plan

- [x] `cargo fmt` クリーン
- [x] `cargo clippy --all-targets -- -D warnings` クリーン
- [x] `cargo test --all` 135/135 pass (既存 125 + 新規 10)
- [ ] 実機 TUI で期限切れキュリオンがログイン時に消えてトーストが出ることを目視確認
- [ ] Collection 一覧に残り寿命表示が出ることを確認
- [ ] Dashboard に「期限切れ間近」警告が出ることを確認