### PR TITLE
feat: 高リスク合成を実装 (#35)

### DIFF
--- a/data/recipes/basic_recipes.json
+++ b/data/recipes/basic_recipes.json
@@ -444,5 +444,74 @@
     },
     "discovery_rate": 0.3,
     "recipe_type": "ChaosMix"
+  },
+  {
+    "id": "recipe_016",
+    "name": "禁断の神",
+    "description": "混沌と秩序を無理やり融合させ、神なるものを呼び寄せる",
+    "ingredients": [
+      {
+        "specific_noun": "混沌",
+        "category": null,
+        "rarity": null,
+        "count": 1
+      },
+      {
+        "specific_noun": "秩序",
+        "category": null,
+        "rarity": null,
+        "count": 1
+      }
+    ],
+    "result": {
+      "noun": "神",
+      "category": "Abstract",
+      "rarity": "Legendary",
+      "synthesis_only": true,
+      "special_attributes": {
+        "interest": 0.3,
+        "beauty": 0.3
+      }
+    },
+    "discovery_rate": 0.5,
+    "recipe_type": "Advanced",
+    "success_rate": 0.25,
+    "failure_mode": { "type": "LoseAll" }
+  },
+  {
+    "id": "recipe_017",
+    "name": "黒い太陽",
+    "description": "光と影を強引に結合する。失敗すれば残骸の灰だけが残る",
+    "ingredients": [
+      {
+        "specific_noun": "光",
+        "category": null,
+        "rarity": null,
+        "count": 1
+      },
+      {
+        "specific_noun": "影",
+        "category": null,
+        "rarity": null,
+        "count": 1
+      }
+    ],
+    "result": {
+      "noun": "黒い太陽",
+      "category": "Phenomenon",
+      "rarity": "Epic",
+      "synthesis_only": true,
+      "special_attributes": {
+        "interest": 0.2,
+        "beauty": 0.15
+      }
+    },
+    "discovery_rate": 0.6,
+    "recipe_type": "Conceptual",
+    "success_rate": 0.50,
+    "failure_mode": {
+      "type": "Salvage",
+      "fallback_rarity": "Common"
+    }
   }
 ]

--- a/docs/design.md
+++ b/docs/design.md
@@ -458,15 +458,59 @@ Collection Owned List 表示:
   - 寿命なし: `寿命: --`
 ```
 
-### High-risk Synthesis (Issue #35)
+### High-risk Synthesis (Issue #35) — IMPLEMENTED
 
 ```
-New section in Synthesis tab: "高リスク合成"
+高リスクレシピは既存の Synthesis タブにインライン表示する (専用 section は作らない)。
 
-Layout:
-  - Show success probability as Gauge (Red when <30%, Yellow <60%, Green ≥60%)
-  - Failure consequence: "失敗時: 素材ロスト" in Red
-  - Confirm dialog before execution: "本当に合成しますか？ (y/n)"
+Data model (src/synthesis.rs):
+  SynthesisRecipe に 2 フィールドを追加 (どちらも #[serde(default)] で後方互換)
+    - success_rate: f64       // 実行時成功率。発見済みでも毎回 roll
+                              //   省略時 1.0 (既存レシピは挙動不変)
+    - failure_mode: FailureMode
+        - NoLoss                       (保険: 失敗しても素材を失わない、既存互換 = default)
+        - LoseAll                      (素材全消滅)
+        - Salvage { fallback_rarity }  (素材を失い、代わりに低レアの残骸 curion 1 個獲得)
+
+  HIGH_RISK_THRESHOLD = 0.95
+  is_high_risk(): success_rate < 0.95
+  success_probability(is_discovered):
+    base = if is_discovered { 1.0 } else { discovery_rate }
+    return base * success_rate    // discovery と success_rate の AND
+
+Execution flow (try_synthesize / try_synthesize_with_rolls):
+  1. find_matching_recipes → 最初の 1 件を採用
+  2. !is_discovered なら discovery_roll で discovery_rate 判定
+     失敗 → DiscoveryFailed (素材は消費しない、risk roll まで到達しない)
+     成功 → discover_recipe で発見済みに昇格
+  3. success_rate < 1.0 かつ risk_roll > success_rate → HighRiskFailure を返す
+     - failure_mode に応じて lost_ingredients / salvage を構築:
+         NoLoss   → lost_ingredients = [], salvage = None
+         LoseAll  → lost_ingredients = ingredients 全件, salvage = None
+         Salvage  → lost_ingredients = ingredients 全件,
+                    salvage = Some(最初の材料の名詞+カテゴリを継承 + 「〜の残骸」, fallback_rarity)
+  4. 上記をすべて通過 → Success
+
+UI side (handle_synthesis_enter):
+  HighRiskFailure を受け取ったら
+    - lost_ingredients を id 一致で player.collection から削除
+    - salvage があれば add_curion で追加 (収集系ミッション進捗にも乗る)
+    - 失敗モード別トースト:
+        LoseAll → "💥 失敗: <recipe_name> (素材消滅)"
+        Salvage → "💔 失敗: <recipe_name> (残骸を獲得)"
+        NoLoss  → "⚠ 失敗: <recipe_name> (保険発動)"
+    - synthesis_state を SelectingFirst に戻す
+
+Display (render_recipe_list / render_second_ingredient_candidates):
+  - SAFE   バッジ: 緑 (COLOR_SUCCESS)
+  - RISKY  バッジ: 赤 (COLOR_BAR_HOT) + "失敗時: 素材消滅 / 残骸獲得 / 保険" の付記
+  - 合成確率バーも RISKY なら赤系で表示し、視覚的に "危険" を強調
+
+Sample recipes in data/recipes/basic_recipes.json:
+  recipe_016 「禁断の神」 混沌 + 秩序 → 神 (Legendary)
+    discovery_rate 0.5 / success_rate 0.25 / failure_mode LoseAll
+  recipe_017 「黒い太陽」 光 + 影 → 黒い太陽 (Epic)
+    discovery_rate 0.6 / success_rate 0.50 / failure_mode Salvage(Common)
 ```
 
 ### Stage Evolution Gacha (Issue #36)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,6 +67,7 @@
 - [x] Stats タブ実装 (#26) — レアリティ BarChart (Gray/Cyan/Yellow/Red)、カテゴリ BarChart、時系列タブの直近 30 日 Sparkline。日次集計は `Player::daily_acquisition_counts(days, now)` の純粋関数に閉じてあり、UI 非依存にテスト可能
 - [x] SAN 値パラメータ (#29) — 正気度 (0.0..=100.0) を `Player::san` に追加。Common +0.5 / Rare +2.0 / Epic +5.0 / Legendary +15.0 / 合成成功 +3.0 / 時間経過 -0.1/min。Dashboard 概要に LineGauge を常時表示し、>= 80 Cyan / 50..80 Yellow / 30..50 Red / < 30 Magenta + `⚠ 異常状態` で警告。変動ロジックは `src/san.rs` のピュア関数 (`san_gain_for_acquisition` / `apply_decay` / `apply_gain` / `san_state`) に閉じて UI 非依存
 - [x] 寿命システム (#30) — レアリティ別寿命 (Common 3 / Rare 7 / Epic 14 / Legendary 30 日) を `Curion::lifespan_days: Option<u32>` で保持し、起動時に `Player::prune_expired` で期限切れキュリオンを自動削除。削除分は TUI トースト (6 秒) / --plain / interactive モードで通知。Collection 一覧の各行に残り寿命を表示 (残 ≤ 0 = 赤、≤ 3 = 黄、それ以上 = グレー、寿命なし = `--`)。Dashboard 概要に「⚠ 期限切れ間近 (残り 1 日以下): N 個」を常時表示 (0 個なら空行)。合成消費は寿命を見ず「使ってあげること = 供養」として扱う。旧セーブは `lifespan_days = None` で復元され永遠扱い (後方互換)
+- [x] 高リスク合成 (#35) — `SynthesisRecipe` に `success_rate` (実行時成功率、デフォルト 1.0) と `failure_mode` (`NoLoss` / `LoseAll` / `Salvage{fallback_rarity}`、デフォルト `NoLoss`) を追加。発見済みでも `success_rate < 1.0` なら毎回 risk roll が走り、失敗時は `SynthesisAttemptResult::HighRiskFailure` を返す。`try_synthesize_with_rolls(ingredients, discovery_roll, risk_roll)` を内部 API として切り出し、UI 非依存にテスト可能。Synthesis レシピ一覧と Ingredient 2 候補に `[SAFE]` / `[RISKY:失敗時挙動]` バッジを併記し、`success_probability(is_discovered)` は discovery × success_rate の積を返す。`basic_recipes.json` に「禁断の神」(混沌+秩序、25% LoseAll Legendary) と「黒い太陽」(光+影、50% Salvage Common) を追加
 - [ ] イベントシステム
 - [ ] ランキング
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -40,11 +40,46 @@ Noun data is stored in `data/nouns/*.json` (one file per category).
 
 Combine two owned curions to create a new one.
 
-- Recipes are defined in `data/recipes/basic_recipes.json` (15 base recipes).
+- Recipes are defined in `data/recipes/basic_recipes.json` (17 recipes: 15 base + 2 high-risk).
 - Recipe format: `material_a + material_b -> result` (matched by category + name).
 - Synthesis-exclusive curions exist (e.g., Flame Dragon, Ice Phoenix) -- obtainable only through synthesis.
 - Smart synthesis UI suggests valid combinations from the player's inventory.
 - Discovered recipes are tracked and shown in the UI.
+
+### High-risk Synthesis (Issue #35)
+
+Each recipe has two independent probability dials:
+
+- `discovery_rate` (existing) — first-time-only roll. Failing this returns
+  `DiscoveryFailed` without consuming ingredients. Once passed, the recipe is
+  marked discovered and the roll is skipped on subsequent attempts.
+- `success_rate` (new, default `1.0`) — execution-time roll applied **every**
+  attempt, including discovered recipes. `success_rate < 0.95` flags the recipe
+  as high-risk (`is_high_risk()`).
+
+Failure behaviour is selected per recipe via `failure_mode`:
+
+| Mode | Effect on inventory | Output |
+|---|---|---|
+| `NoLoss` (default) | nothing lost | nothing gained |
+| `LoseAll` | both ingredients deleted | nothing |
+| `Salvage { fallback_rarity }` | both ingredients deleted | 1 salvage curion at `fallback_rarity`, named "`<first>の残骸`", inheriting the first ingredient's category |
+
+The displayed success probability is `discovery_factor * success_rate`, where
+`discovery_factor` is `discovery_rate` for undiscovered recipes and `1.0` for
+discovered ones. UI shows `[SAFE]` / `[RISKY]` badges plus the failure-mode
+label on both the recipe list and the ingredient-2 candidate list.
+
+`SynthesisAttemptResult::HighRiskFailure { recipe_name, lost_ingredients,
+salvage, failure_mode }` is returned on a failed risk roll. The UI layer is
+responsible for removing `lost_ingredients` (matched by `id`) and adding any
+`salvage` curion. The internal `try_synthesize_with_rolls(ingredients,
+discovery_roll, risk_roll)` API allows deterministic testing of the two-stage
+roll without random sources.
+
+Recipe JSON is backward compatible: existing recipes without `success_rate` /
+`failure_mode` deserialize to `1.0` / `NoLoss`, so all 15 legacy recipes remain
+100% safe.
 
 ## Lifespan System (Issue #30)
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -496,6 +496,33 @@ fn cmd_synthesize(name1: &str, name2: &str, game_state: &mut GameState) -> Resul
         SynthesisAttemptResult::DiscoveryFailed { hint } => {
             println!("  {hint}");
         }
+        SynthesisAttemptResult::HighRiskFailure {
+            recipe_name,
+            lost_ingredients,
+            salvage,
+            failure_mode,
+        } => {
+            // Issue #35: 高リスク合成失敗の演出 (赤表示)
+            // 失われた材料を collection から除去 (NoLoss モードでは lost_ingredients が空)
+            for ci in &lost_ingredients {
+                game_state.player.collection.retain(|c| c.id != ci.id);
+            }
+            let mode_label = match failure_mode {
+                crate::synthesis::FailureMode::LoseAll => "素材消滅",
+                crate::synthesis::FailureMode::Salvage { .. } => "残骸を獲得",
+                crate::synthesis::FailureMode::NoLoss => "保険発動",
+            };
+            println!("  \x1b[1;31m💥 失敗: {recipe_name} ({mode_label})\x1b[0m");
+            if let Some(s) = salvage {
+                println!(
+                    "  Salvage: \x1b[37m{:?}\x1b[0m {} [{}]",
+                    s.rarity,
+                    s.noun,
+                    s.category.as_str(),
+                );
+                game_state.add_curion(s);
+            }
+        }
     }
 
     Ok(())

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -143,6 +143,32 @@ pub fn run_plain_mode(profile_manager: &ProfileManager, args: &[String]) -> Resu
                 SynthesisAttemptResult::NoRecipe => {
                     println!("[NO RECIPE] no matching recipe for {a_noun} + {b_noun}");
                 }
+                SynthesisAttemptResult::HighRiskFailure {
+                    recipe_name,
+                    lost_ingredients,
+                    salvage,
+                    failure_mode,
+                } => {
+                    // Issue #35: 高リスク失敗。LoseAll/Salvage の場合は素材を削除する。
+                    // インデックスベースで削除すると順序が変わるので、id ベースで除去する。
+                    for ci in &lost_ingredients {
+                        game_state.player.collection.retain(|c| c.id != ci.id);
+                    }
+                    let mode_label = match &failure_mode {
+                        crate::synthesis::FailureMode::LoseAll => "lose_all",
+                        crate::synthesis::FailureMode::Salvage { .. } => "salvage",
+                        crate::synthesis::FailureMode::NoLoss => "no_loss",
+                    };
+                    println!(
+                        "[HIGH-RISK FAIL] {} + {} => x (recipe: {}, mode: {})",
+                        a_noun, b_noun, recipe_name, mode_label
+                    );
+                    if let Some(s) = salvage {
+                        println!("  Salvage: {} [{}]", s.noun, rarity_tag(s.rarity),);
+                        game_state.add_curion(s);
+                    }
+                    save_manager.save(&game_state)?;
+                }
             }
         }
 

--- a/src/synthesis.rs
+++ b/src/synthesis.rs
@@ -16,6 +16,40 @@ pub struct SynthesisRecipe {
     pub result: SynthesisResult,
     pub discovery_rate: f64, // 初見成功率（0.0〜1.0）
     pub recipe_type: RecipeType,
+
+    /// Issue #35: 発見済みレシピでも適用される「実行時成功率」。
+    /// `discovery_rate` とは別軸で、`is_discovered == true` でも毎回 roll される。
+    /// 既存レシピ (フィールド省略) は 1.0 (= 100% 成功) として扱われる。
+    #[serde(default = "default_success_rate")]
+    pub success_rate: f64,
+
+    /// Issue #35: 失敗時にどう振る舞うか。デフォルトは `NoLoss` (保険) で、
+    /// 既存レシピの挙動 (素材は消費しない / 副作用なし) と一致する。
+    #[serde(default)]
+    pub failure_mode: FailureMode,
+}
+
+fn default_success_rate() -> f64 {
+    1.0
+}
+
+/// Issue #35: 高リスク合成のリスクしきい値。
+/// `success_rate` がこれより小さい場合に "RISKY" として扱う。
+pub const HIGH_RISK_THRESHOLD: f64 = 0.95;
+
+/// Issue #35: 失敗時の挙動パターン。
+/// `Default = NoLoss` で既存レシピ互換 (失敗ロスなし) を担保する。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(tag = "type")]
+pub enum FailureMode {
+    /// 何も失わない (保険)。素材は手元に残り、結果も出ない。
+    #[default]
+    NoLoss,
+    /// 素材を全て失う (デフォルトの高リスク失敗)。
+    LoseAll,
+    /// 素材を失い、代わりに残骸 curion を 1 個得る。
+    /// `fallback_rarity` のレアリティで、材料のうち最初のものを名詞元として残骸を生成する。
+    Salvage { fallback_rarity: Rarity },
 }
 
 impl SynthesisRecipe {
@@ -27,11 +61,19 @@ impl SynthesisRecipe {
     /// 計算はロジック層に閉じており、UI 層は本メソッドを呼ぶだけで
     /// 表示用の確率を得られる。
     pub fn success_probability(&self, is_discovered: bool) -> f64 {
-        if is_discovered {
+        let base = if is_discovered {
             1.0
         } else {
             self.discovery_rate.clamp(0.0, 1.0)
-        }
+        };
+        // Issue #35: 発見済みでも success_rate < 1.0 なら毎回 roll する。
+        // 表示用の確率は discovery と success_rate の AND (積) で表現する。
+        base * self.success_rate.clamp(0.0, 1.0)
+    }
+
+    /// Issue #35: 高リスクレシピ (`success_rate < HIGH_RISK_THRESHOLD`) か判定する。
+    pub fn is_high_risk(&self) -> bool {
+        self.success_rate < HIGH_RISK_THRESHOLD
     }
 }
 
@@ -208,6 +250,24 @@ impl SynthesisManager {
 
     /// 合成を試みる
     pub fn try_synthesize(&mut self, ingredients: Vec<Curion>) -> Result<SynthesisAttemptResult> {
+        let discovery_roll: f64 = rand::random();
+        let risk_roll: f64 = rand::random();
+        self.try_synthesize_with_rolls(ingredients, discovery_roll, risk_roll)
+    }
+
+    /// Issue #35: テスト用に乱数を外部注入できる内部 API。
+    ///
+    /// - `discovery_roll`: 未発見レシピの `discovery_rate` 判定に使う。
+    ///   `discovery_roll > discovery_rate` で `DiscoveryFailed`。
+    /// - `risk_roll`: `success_rate` 判定に使う。`risk_roll > success_rate` で `HighRiskFailure`。
+    ///
+    /// `try_synthesize` の薄いラッパで本実装。
+    pub fn try_synthesize_with_rolls(
+        &mut self,
+        ingredients: Vec<Curion>,
+        discovery_roll: f64,
+        risk_roll: f64,
+    ) -> Result<SynthesisAttemptResult> {
         // マッチするレシピを検索
         let matching_recipes = self.recipe_db.find_matching_recipes(&ingredients);
 
@@ -222,6 +282,8 @@ impl SynthesisManager {
         let recipe_id = recipe.id.clone();
         let recipe_name = recipe.name.clone();
         let discovery_rate = recipe.discovery_rate;
+        let success_rate = recipe.success_rate;
+        let failure_mode = recipe.failure_mode.clone();
         let result_curion = recipe.result.to_curion();
 
         // 発見済みか確認
@@ -229,15 +291,19 @@ impl SynthesisManager {
 
         // 未発見の場合、discovery_rateで成功判定
         if !is_discovered {
-            let roll: f64 = rand::random();
-            if roll > discovery_rate {
+            if discovery_roll > discovery_rate {
                 return Ok(SynthesisAttemptResult::DiscoveryFailed {
                     hint: "何かが起こりそうだが、まだ完全には理解できていない...".to_string(),
                 });
             }
-
             // 発見成功！
             self.discover_recipe(recipe_id);
+        }
+
+        // Issue #35: success_rate < 1.0 の場合は実行時 roll を毎回行う。
+        // discovery 判定を通過した後に行うため、未発見初回でも risk 判定が走る。
+        if success_rate < 1.0 && risk_roll > success_rate {
+            return Ok(self.build_high_risk_failure(recipe_name, ingredients, failure_mode));
         }
 
         // 合成成功
@@ -246,6 +312,49 @@ impl SynthesisManager {
             recipe_name,
             first_discovery: !is_discovered,
         })
+    }
+
+    /// Issue #35: failure_mode に応じた `HighRiskFailure` を組み立てる。
+    fn build_high_risk_failure(
+        &self,
+        recipe_name: String,
+        ingredients: Vec<Curion>,
+        failure_mode: FailureMode,
+    ) -> SynthesisAttemptResult {
+        match &failure_mode {
+            FailureMode::NoLoss => SynthesisAttemptResult::HighRiskFailure {
+                recipe_name,
+                lost_ingredients: Vec::new(),
+                salvage: None,
+                failure_mode,
+            },
+            FailureMode::LoseAll => SynthesisAttemptResult::HighRiskFailure {
+                recipe_name,
+                lost_ingredients: ingredients,
+                salvage: None,
+                failure_mode,
+            },
+            FailureMode::Salvage { fallback_rarity } => {
+                // 残骸は最初の材料の名詞・カテゴリを引き継ぎつつ、レアリティを fallback まで落とす。
+                // 「残骸」というイメージなので interest/beauty は低めに固定。
+                let salvage_curion = ingredients.first().map(|src| {
+                    Curion::new(
+                        Uuid::new_v4(),
+                        format!("{}の残骸", src.noun),
+                        src.category.clone(),
+                        *fallback_rarity,
+                        0.3,
+                        0.3,
+                    )
+                });
+                SynthesisAttemptResult::HighRiskFailure {
+                    recipe_name,
+                    lost_ingredients: ingredients,
+                    salvage: salvage_curion,
+                    failure_mode,
+                }
+            }
+        }
     }
 
     /// 発見済みレシピの数
@@ -382,6 +491,16 @@ pub enum SynthesisAttemptResult {
     DiscoveryFailed {
         hint: String,
     },
+    /// Issue #35: 高リスクレシピで `success_rate` 判定に失敗したケース。
+    HighRiskFailure {
+        recipe_name: String,
+        /// 失われた材料 (UI 側で collection から削除するために使う)。
+        /// `failure_mode == NoLoss` の場合は空。
+        lost_ingredients: Vec<Curion>,
+        /// 残骸 curion (`failure_mode == Salvage` の場合のみ Some)。
+        salvage: Option<Curion>,
+        failure_mode: FailureMode,
+    },
 }
 
 #[cfg(test)]
@@ -442,7 +561,66 @@ mod tests {
             },
             discovery_rate,
             recipe_type: RecipeType::Intuitive,
+            success_rate: 1.0,
+            failure_mode: FailureMode::NoLoss,
         }
+    }
+
+    /// Issue #35: 「水 + 火」のような 2 材料レシピを動的に作る。テスト専用。
+    fn make_pair_recipe(
+        id: &str,
+        result_noun: &str,
+        ingredient_a: &str,
+        ingredient_b: &str,
+        success_rate: f64,
+        failure_mode: FailureMode,
+    ) -> SynthesisRecipe {
+        SynthesisRecipe {
+            id: id.to_string(),
+            name: result_noun.to_string(),
+            description: "test pair recipe".to_string(),
+            ingredients: vec![
+                IngredientRequirement {
+                    specific_noun: Some(ingredient_a.to_string()),
+                    category: None,
+                    rarity: None,
+                    count: 1,
+                },
+                IngredientRequirement {
+                    specific_noun: Some(ingredient_b.to_string()),
+                    category: None,
+                    rarity: None,
+                    count: 1,
+                },
+            ],
+            result: SynthesisResult {
+                noun: result_noun.to_string(),
+                category: Category::Concept,
+                rarity: Rarity::Epic,
+                synthesis_only: true,
+                special_attributes: HashMap::new(),
+            },
+            discovery_rate: 1.0,
+            recipe_type: RecipeType::Advanced,
+            success_rate,
+            failure_mode,
+        }
+    }
+
+    fn manager_with_recipes(recipes: Vec<SynthesisRecipe>) -> SynthesisManager {
+        let db = RecipeDatabase { recipes };
+        SynthesisManager::new(db)
+    }
+
+    fn make_curion(noun: &str) -> Curion {
+        Curion::new(
+            Uuid::new_v4(),
+            noun.to_string(),
+            Category::Element,
+            Rarity::Common,
+            0.5,
+            0.5,
+        )
     }
 
     /// Issue #28: 未発見レシピの成功確率は `discovery_rate` と一致する
@@ -475,5 +653,228 @@ mod tests {
         manager.discover_recipe(recipe_id);
         let discovered_p = manager.success_probability_for_recipe(&recipe);
         assert!((discovered_p - 1.0).abs() < 1e-9);
+    }
+
+    // ---------- Issue #35: 高リスク合成 ----------
+
+    /// Issue #35: JSON で `success_rate` 省略時はデフォルト 1.0 になる。
+    #[test]
+    fn test_synthesis_recipe_default_success_rate_is_1() {
+        // success_rate / failure_mode を持たない旧レシピ JSON を再現
+        let legacy_json = r#"{
+            "id": "legacy_recipe",
+            "name": "レガシー",
+            "description": "old style",
+            "ingredients": [],
+            "result": {
+                "noun": "x",
+                "category": "Concept",
+                "rarity": "Common",
+                "synthesis_only": false,
+                "special_attributes": {}
+            },
+            "discovery_rate": 0.8,
+            "recipe_type": "Intuitive"
+        }"#;
+        let recipe: SynthesisRecipe =
+            serde_json::from_str(legacy_json).expect("legacy recipe parse");
+        assert!((recipe.success_rate - 1.0).abs() < 1e-9);
+        assert_eq!(recipe.failure_mode, FailureMode::NoLoss);
+    }
+
+    /// Issue #35: 既存レシピは high-risk 扱いにならない (= 100% 成功)。
+    #[test]
+    fn test_is_high_risk_threshold() {
+        // success_rate がしきい値より上なら non-high-risk
+        let mut r = sample_recipe(1.0);
+        r.success_rate = 1.0;
+        assert!(!r.is_high_risk());
+
+        r.success_rate = 0.95;
+        assert!(!r.is_high_risk(), "0.95 はしきい値ちょうど (非リスク)");
+
+        r.success_rate = 0.94;
+        assert!(r.is_high_risk(), "0.94 未満は high risk");
+
+        r.success_rate = 0.30;
+        assert!(r.is_high_risk());
+    }
+
+    /// Issue #35: success_rate 100% なら、risk_roll に関係なく Success を返す。
+    #[test]
+    fn test_try_synthesize_legacy_recipe_always_succeeds() {
+        let recipe = make_pair_recipe("legacy", "結果", "水", "火", 1.0, FailureMode::LoseAll);
+        let mut mgr = manager_with_recipes(vec![recipe]);
+        let ingredients = vec![make_curion("水"), make_curion("火")];
+
+        // risk_roll が 0.99 (= 普通なら高リスクで失敗するレベル) でも、
+        // success_rate=1.0 なら成功する。discovery_roll も成功側にしておく。
+        let result = mgr
+            .try_synthesize_with_rolls(ingredients, 0.0, 0.99)
+            .expect("synthesize");
+        assert!(matches!(result, SynthesisAttemptResult::Success { .. }));
+    }
+
+    /// Issue #35: risk_roll が success_rate 以下なら成功する。
+    #[test]
+    fn test_try_synthesize_high_risk_success() {
+        let recipe = make_pair_recipe("risky", "禁断", "水", "火", 0.30, FailureMode::LoseAll);
+        let mut mgr = manager_with_recipes(vec![recipe]);
+        let ingredients = vec![make_curion("水"), make_curion("火")];
+
+        // discovery 成功 + risk 成功 (roll 0.10 <= 0.30)
+        let result = mgr
+            .try_synthesize_with_rolls(ingredients, 0.0, 0.10)
+            .expect("synthesize");
+        assert!(matches!(result, SynthesisAttemptResult::Success { .. }));
+    }
+
+    /// Issue #35: risk_roll が success_rate を超えると HighRiskFailure を返す。
+    /// LoseAll モードでは lost_ingredients に全材料が入る。
+    #[test]
+    fn test_try_synthesize_high_risk_failure_loseall() {
+        let recipe = make_pair_recipe("risky", "禁断", "水", "火", 0.30, FailureMode::LoseAll);
+        let mut mgr = manager_with_recipes(vec![recipe]);
+        let water = make_curion("水");
+        let fire = make_curion("火");
+        let water_id = water.id.clone();
+        let fire_id = fire.id.clone();
+        let ingredients = vec![water, fire];
+
+        // risk_roll 0.80 > 0.30 → 失敗
+        let result = mgr
+            .try_synthesize_with_rolls(ingredients, 0.0, 0.80)
+            .expect("synthesize");
+        match result {
+            SynthesisAttemptResult::HighRiskFailure {
+                lost_ingredients,
+                salvage,
+                failure_mode,
+                ..
+            } => {
+                assert_eq!(failure_mode, FailureMode::LoseAll);
+                assert_eq!(lost_ingredients.len(), 2);
+                let lost_ids: Vec<String> = lost_ingredients.iter().map(|c| c.id.clone()).collect();
+                assert!(lost_ids.contains(&water_id));
+                assert!(lost_ids.contains(&fire_id));
+                assert!(salvage.is_none());
+            }
+            other => panic!("expected HighRiskFailure, got {other:?}"),
+        }
+    }
+
+    /// Issue #35: NoLoss モードでは失敗しても素材は失われない (lost_ingredients が空)。
+    #[test]
+    fn test_try_synthesize_failure_mode_noloss_no_lost_ingredients() {
+        let recipe = make_pair_recipe("insured", "保険", "水", "火", 0.30, FailureMode::NoLoss);
+        let mut mgr = manager_with_recipes(vec![recipe]);
+        let ingredients = vec![make_curion("水"), make_curion("火")];
+
+        let result = mgr
+            .try_synthesize_with_rolls(ingredients, 0.0, 0.80)
+            .expect("synthesize");
+        match result {
+            SynthesisAttemptResult::HighRiskFailure {
+                lost_ingredients,
+                salvage,
+                failure_mode,
+                ..
+            } => {
+                assert_eq!(failure_mode, FailureMode::NoLoss);
+                assert!(lost_ingredients.is_empty(), "NoLoss は素材を失わない");
+                assert!(salvage.is_none());
+            }
+            other => panic!("expected HighRiskFailure, got {other:?}"),
+        }
+    }
+
+    /// Issue #35: Salvage モードは lost_ingredients + 残骸 curion を返す。
+    #[test]
+    fn test_try_synthesize_failure_mode_salvage_produces_salvage_curion() {
+        let recipe = make_pair_recipe(
+            "salvage",
+            "残骸テスト",
+            "水",
+            "火",
+            0.30,
+            FailureMode::Salvage {
+                fallback_rarity: Rarity::Common,
+            },
+        );
+        let mut mgr = manager_with_recipes(vec![recipe]);
+        let ingredients = vec![make_curion("水"), make_curion("火")];
+
+        let result = mgr
+            .try_synthesize_with_rolls(ingredients, 0.0, 0.95)
+            .expect("synthesize");
+        match result {
+            SynthesisAttemptResult::HighRiskFailure {
+                lost_ingredients,
+                salvage,
+                failure_mode,
+                ..
+            } => {
+                assert!(matches!(failure_mode, FailureMode::Salvage { .. }));
+                assert_eq!(lost_ingredients.len(), 2);
+                let salvage = salvage.expect("salvage curion should be produced");
+                assert_eq!(salvage.rarity, Rarity::Common);
+                assert!(salvage.noun.contains("残骸"));
+            }
+            other => panic!("expected HighRiskFailure, got {other:?}"),
+        }
+    }
+
+    /// Issue #35: discovery 判定に失敗した場合は risk 判定まで到達せず、
+    /// `DiscoveryFailed` が返ることで素材ロストの誤発火が起きない。
+    #[test]
+    fn test_try_synthesize_discovery_failure_does_not_trigger_risk_failure() {
+        // discovery_rate を低く設定したいので make_pair_recipe を上書きする
+        let mut recipe = make_pair_recipe("risky", "禁断", "水", "火", 0.50, FailureMode::LoseAll);
+        recipe.discovery_rate = 0.10;
+        let mut mgr = manager_with_recipes(vec![recipe]);
+        let ingredients = vec![make_curion("水"), make_curion("火")];
+
+        // discovery_roll 0.50 > 0.10 → 発見失敗
+        let result = mgr
+            .try_synthesize_with_rolls(ingredients, 0.50, 0.0)
+            .expect("synthesize");
+        assert!(matches!(
+            result,
+            SynthesisAttemptResult::DiscoveryFailed { .. }
+        ));
+    }
+
+    /// Issue #35: 発見済みレシピで success_rate < 1.0 の場合、毎回 risk roll が走る。
+    #[test]
+    fn test_try_synthesize_discovered_still_rolls_risk() {
+        let recipe = make_pair_recipe("risky", "禁断", "水", "火", 0.30, FailureMode::LoseAll);
+        let recipe_id = recipe.id.clone();
+        let mut mgr = manager_with_recipes(vec![recipe]);
+        mgr.discover_recipe(recipe_id);
+
+        let ingredients = vec![make_curion("水"), make_curion("火")];
+        // 発見済みでも risk_roll 0.99 > 0.30 → 失敗
+        let result = mgr
+            .try_synthesize_with_rolls(ingredients, 0.0, 0.99)
+            .expect("synthesize");
+        assert!(matches!(
+            result,
+            SynthesisAttemptResult::HighRiskFailure { .. }
+        ));
+    }
+
+    /// Issue #35: 表示用の `success_probability` は discovery × success_rate の積。
+    #[test]
+    fn test_success_probability_combines_discovery_and_success_rate() {
+        let mut recipe = sample_recipe(0.50);
+        recipe.success_rate = 0.40;
+
+        // 未発見: 0.50 * 0.40 = 0.20
+        let undiscovered = recipe.success_probability(false);
+        assert!((undiscovered - 0.20).abs() < 1e-9);
+
+        // 発見済み: 1.0 * 0.40 = 0.40
+        let discovered = recipe.success_probability(true);
+        assert!((discovered - 0.40).abs() < 1e-9);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -650,6 +650,45 @@ impl App {
                                         self.save_message =
                                             Some(("No recipe found".to_string(), Instant::now()));
                                     }
+                                    // Issue #35: 高リスク合成失敗の処理。
+                                    // - lost_ingredients を collection から id 一致で除去
+                                    // - salvage curion があれば add_curion で追加 (Curion 加算系
+                                    //   ミッションも record_curion_acquired 経由で進捗する)
+                                    // - 失敗モードに応じた赤系トーストを表示
+                                    SynthesisAttemptResult::HighRiskFailure {
+                                        recipe_name,
+                                        lost_ingredients,
+                                        salvage,
+                                        failure_mode,
+                                    } => {
+                                        for ci in &lost_ingredients {
+                                            self.game_state
+                                                .player
+                                                .collection
+                                                .retain(|c| c.id != ci.id);
+                                        }
+                                        if let Some(s) = salvage {
+                                            self.game_state.add_curion(s);
+                                            self.flush_daily_mission_rewards();
+                                        }
+                                        let msg = match failure_mode {
+                                            crate::synthesis::FailureMode::LoseAll => {
+                                                format!("💥 失敗: {recipe_name} (素材消滅)")
+                                            }
+                                            crate::synthesis::FailureMode::Salvage { .. } => {
+                                                format!("💔 失敗: {recipe_name} (残骸を獲得)")
+                                            }
+                                            crate::synthesis::FailureMode::NoLoss => {
+                                                format!("⚠ 失敗: {recipe_name} (保険発動)")
+                                            }
+                                        };
+                                        self.save_message = Some((msg, Instant::now()));
+
+                                        self.synthesis_state = SynthesisUIState::SelectingFirst;
+                                        self.selected_first_curion = None;
+                                        self.synthesis_scroll = 0;
+                                        self.detail_scroll = 0;
+                                    }
                                 }
                             }
                         }
@@ -2783,18 +2822,44 @@ impl App {
                 };
 
                 // Issue #28: 合成成功確率を LineGauge 風に表示
+                // Issue #35: 高リスクレシピは赤系で SAFE/RISKY バッジを併記する
                 let success_p = self
                     .game_state
                     .synthesis_manager
                     .success_probability_for_recipe(recipe);
                 let success_pct = (success_p * 100.0).round() as u16;
-                let probability_color = if discovered {
+                let is_risky = recipe.is_high_risk();
+                let probability_color = if is_risky {
+                    COLOR_BAR_HOT
+                } else if discovered {
                     COLOR_SUCCESS
                 } else {
                     COLOR_RARE
                 };
+                let (badge_text, badge_color) = if is_risky {
+                    ("[RISKY]", COLOR_BAR_HOT)
+                } else {
+                    ("[SAFE]", COLOR_SUCCESS)
+                };
+                // 失敗時挙動の説明文 (RISKY のみ表示)
+                let failure_hint = if is_risky {
+                    match &recipe.failure_mode {
+                        crate::synthesis::FailureMode::LoseAll => " 失敗時: 素材消滅",
+                        crate::synthesis::FailureMode::Salvage { .. } => " 失敗時: 残骸獲得",
+                        crate::synthesis::FailureMode::NoLoss => " 失敗時: 保険",
+                    }
+                } else {
+                    ""
+                };
                 let probability_line = Line::from(vec![
                     Span::raw("    "),
+                    Span::styled(
+                        badge_text,
+                        Style::default()
+                            .fg(badge_color)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(" "),
                     Span::styled("合成確率: ", Style::default().fg(COLOR_LABEL)),
                     Span::styled(
                         format!("{success_pct:>3}% "),
@@ -2806,6 +2871,7 @@ impl App {
                         format!("[{}]", bar(success_p, 10)),
                         Style::default().fg(probability_color),
                     ),
+                    Span::styled(failure_hint, Style::default().fg(COLOR_BAR_HOT)),
                 ]);
 
                 ListItem::new(vec![
@@ -2896,6 +2962,7 @@ impl App {
                 // Issue #28: この候補で実際に通るレシピの成功確率を表示
                 // (first + candidate) が複数レシピにマッチする可能性もあるので、
                 // 「最初にヒットするレシピ」(try_synthesize の挙動と一致) の確率を見せる。
+                // Issue #35: 高リスクレシピは [RISKY] バッジ + 失敗時挙動も併記。
                 let probability_text = self
                     .first_matching_recipe_for_pair(first_curion, &candidate.noun)
                     .map(|recipe| {
@@ -2903,10 +2970,21 @@ impl App {
                             .game_state
                             .synthesis_manager
                             .success_probability_for_recipe(recipe);
+                        let badge = if recipe.is_high_risk() {
+                            let mode = match &recipe.failure_mode {
+                                crate::synthesis::FailureMode::LoseAll => "素材消滅",
+                                crate::synthesis::FailureMode::Salvage { .. } => "残骸獲得",
+                                crate::synthesis::FailureMode::NoLoss => "保険",
+                            };
+                            format!(" [RISKY:{mode}]")
+                        } else {
+                            " [SAFE]".to_string()
+                        };
                         format!(
-                            " — 合成確率 {:>3}% [{}]",
+                            " — 合成確率 {:>3}% [{}]{}",
                             (p * 100.0).round() as u16,
-                            bar(p, 8)
+                            bar(p, 8),
+                            badge,
                         )
                     })
                     .unwrap_or_default();


### PR DESCRIPTION
closes #35

## Summary

- `SynthesisRecipe` に `success_rate` (デフォルト 1.0) と `failure_mode`
  (`NoLoss` / `LoseAll` / `Salvage{fallback_rarity}`, デフォルト `NoLoss`) を追加。
  両フィールドは `#[serde(default)]` 付きで既存 15 レシピは挙動不変。
- 発見済みレシピでも `success_rate < 1.0` なら毎回 risk roll が走る。
  内部 API `try_synthesize_with_rolls(ingredients, discovery_roll, risk_roll)`
  を切り出して乱数を外部注入できるようにし、deterministic にテスト可能。
- 失敗時は新バリアント `SynthesisAttemptResult::HighRiskFailure { recipe_name,
  lost_ingredients, salvage, failure_mode }` を返す。UI 層で `lost_ingredients`
  を id 一致で `player.collection` から削除し、`salvage` があれば `add_curion`。
- `success_probability(is_discovered)` は `discovery × success_rate` の積を返す
  (既存テストは `success_rate=1.0` なので不変)。
- Synthesis レシピ一覧と Ingredient 2 候補に `[SAFE]` / `[RISKY:失敗時挙動]`
  バッジを併記。RISKY は赤系 (`COLOR_BAR_HOT`) で「素材消滅 / 残骸獲得 / 保険」も
  併記し、視覚的にリスクを明示。
- `basic_recipes.json` に高リスクレシピ 2 件を追加
  - `recipe_016` 「禁断の神」 混沌+秩序 → 神 (Legendary), 25% LoseAll
  - `recipe_017` 「黒い太陽」 光+影 → 黒い太陽 (Epic), 50% Salvage(Common)
- TUI / `--plain` / interactive 全モードで `HighRiskFailure` を処理し、
  失敗モード別の赤系トースト / ログを表示。
- `docs/spec.md` / `docs/design.md` / `docs/roadmap.md` を更新。

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (0 warnings)
- [x] `cargo test --all` -> 145/145 passed (既存 135 + 新規 10)
- [x] `cargo run -- --plain status` で起動確認
- [ ] (手動) TUI 起動して合成タブで `[SAFE]` / `[RISKY]` 表示確認
- [ ] (手動) recipe_016 / 017 を実機で実行して LoseAll / Salvage 演出確認

## 新規テスト (10 件)

`src/synthesis.rs::tests`:
- `test_synthesis_recipe_default_success_rate_is_1`
- `test_is_high_risk_threshold` (境界 0.95)
- `test_try_synthesize_legacy_recipe_always_succeeds`
- `test_try_synthesize_high_risk_success`
- `test_try_synthesize_high_risk_failure_loseall`
- `test_try_synthesize_failure_mode_noloss_no_lost_ingredients`
- `test_try_synthesize_failure_mode_salvage_produces_salvage_curion`
- `test_try_synthesize_discovery_failure_does_not_trigger_risk_failure`
- `test_try_synthesize_discovered_still_rolls_risk`
- `test_success_probability_combines_discovery_and_success_rate`