### PR TITLE
chore: v0.2.0 リリース準備 (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-## Unreleased
+## v0.2.0 - 2026-05-17
+
+The "single-player addiction" release: every system needed to make a focused offline session feel rewarding is now in place.
+
+### Added
+- 図鑑機能 (#18): Collection tab dictionary listing every noun across all categories with locked `？？？` placeholders and per-category progress.
+- デイリーミッション (#20): three date-seeded daily missions on the Dashboard with auto-claim and XP rewards.
+- コンボシステム (#21): consecutive Rare+ pulls grant escalating XP multipliers and the "コンボマスター" title at combo 5.
+- フレーバーテキスト (#22): every one of the 268 nouns now carries a sci-fi flavor line, surfaced in the Collection detail pane and dictionary.
+- レア出現予告クールダウン (#25): 4-hour LineGauge cooldown on the Dashboard that boosts Rare+ probability up to 2x at full charge.
+- 入手履歴 (#27): each curion remembers its global acquisition index (continues across synthesis consumption).
+- 行動前確率表示 (#28): success rate gauges for synthesis recipes and live rarity probability percentages on the Dashboard.
+- SAN 値 (#29): sanity stat with rarity-based gains, time-based decay, and a Dashboard Gauge with color thresholds.
+- 寿命システム (#30): rarity-tiered expiration with Dashboard warnings and automatic pruning at login.
+- 正規表現フィルタ (#31): `/` opens regex search across Collection (name / display name / rarity / category).
+- きりの悪い数字設計 (#32): non-linear XP thresholds and achievement counts plus a "next milestone" indicator.
+- Stats タブ仕上げ (#26): daily 30-day Sparkline for collection rate.
+- 高リスク合成 (#35): per-recipe `success_rate` and `failure_mode` (NoLoss / LoseAll / Salvage) with SAFE/RISKY badges.
+- 段階進化ガチャ (#36): 3-stage evolution lines tracked by collection counts, with "almost complete" highlights on the Dashboard.
+- 部分公開レシピ (#37): per-recipe `Public` / `Partial` / `Unknown` visibility levels with progressively revealed labels.
 
 ### Changed
 - Docs reorganized: `DESIGN.md` moved to `docs/design.md`; `.claude/*.md` (vision / synthesis_and_p2p_design / p2p_detailed_design / addictive_ideas / implementation_roadmap) moved under `docs/` with lowercase filenames. The `.claude/` directory was removed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "curion"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curion"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["kako-jun"]
 description = "A SF collection game where you gather particles of curiosity"


### PR DESCRIPTION
## 関連 Issue
closes #33

## 変更内容
- `Cargo.toml` を `0.1.3` → `0.2.0` にバンプ
- `CHANGELOG.md` に v0.2.0 セクションを追加（14 件の Issue を網羅）

## v0.2.0 の意義
Issue #33「シングルモードで中毒になれる状態」の達成。
本リリースで以下が単一バージョンに揃った:

| Issue | 機能 |
|---|---|
| #18 | 図鑑機能 |
| #20 | デイリーミッション |
| #21 | コンボシステム |
| #22 | フレーバーテキスト（268 名詞）|
| #25 | レア出現予告クールダウン |
| #26 | Stats タブ仕上げ |
| #27 | 入手履歴 |
| #28 | 行動前確率表示 |
| #29 | SAN 値 |
| #30 | 寿命システム |
| #31 | 正規表現フィルタ |
| #32 | きりの悪い数字設計 |
| #35 | 高リスク合成 |
| #36 | 段階進化ガチャ |
| #37 | 部分公開レシピ |

## マージ後の作業（kako-jun 手動）
1. main の HEAD に `git tag v0.2.0` → `git push --tags`
2. `gh release create v0.2.0 --notes-from-tag` で GitHub Release 作成
3. `cargo publish` で crates.io に公開（Neo 上の token を使用）

## 検証
- [x] `cargo build --release` 成功
- [x] `cargo test --all` 164/164 pass
- [x] `cargo clippy --all-targets -- -D warnings` クリーン
- [ ] 実機 TUI で全タブを目視確認（kako-jun 担当）