### PR TITLE
feat: kako-jun/curion#65 flavor_en for all 268 nouns (i18n Phase 2)

### DIFF
--- a/data/nouns/abstracts.json
+++ b/data/nouns/abstracts.json
@@ -4,363 +4,415 @@
     "reading": "あい",
     "english": "love",
     "weight": 1.0,
-    "flavor": "観測者と対象を区別しなくなる、結合の興味を宿す粒子。万有引力の心理学的形態。"
+    "flavor": "観測者と対象を区別しなくなる、結合の興味を宿す粒子。万有引力の心理学的形態。",
+    "flavor_en": "A particle bearing the interest of union, where observer and object cease to be distinguished. A psychological form of universal gravitation."
   },
   {
     "name": "美",
     "reading": "び",
     "english": "beauty",
     "weight": 1.0,
-    "flavor": "認識した瞬間に呼吸を変える、調和の興味を宿す粒子。理由を超えて魂を立ち止まらせる。"
+    "flavor": "認識した瞬間に呼吸を変える、調和の興味を宿す粒子。理由を超えて魂を立ち止まらせる。",
+    "flavor_en": "A particle bearing the interest of harmony, altering one's breath at the moment of recognition. It halts the soul beyond reason."
   },
   {
     "name": "自由",
     "reading": "じゆう",
     "english": "freedom",
     "weight": 1.0,
-    "flavor": "選択肢の総和ではなく選び抜く力、解放の興味の粒子。重みに耐えられる者にだけ宿る。"
+    "flavor": "選択肢の総和ではなく選び抜く力、解放の興味の粒子。重みに耐えられる者にだけ宿る。",
+    "flavor_en": "A particle of the interest of liberation, not the sum of choices but the power to choose through. It dwells only in those who can bear its weight."
   },
   {
     "name": "勇気",
     "reading": "ゆうき",
     "english": "courage",
     "weight": 1.0,
-    "flavor": "恐れを抱えたまま前へ進む、決断の興味を宿す粒子。震える手のまま剣を握れる強さ。"
+    "flavor": "恐れを抱えたまま前へ進む、決断の興味を宿す粒子。震える手のまま剣を握れる強さ。",
+    "flavor_en": "A particle bearing the interest of decision, advancing while still holding fear. The strength to grasp the sword with a trembling hand."
   },
   {
     "name": "希望",
     "reading": "きぼう",
     "english": "hope",
     "weight": 1.0,
-    "flavor": "暗闇の中で発光する、微小だが切れない興味の粒子。今ここを未来から照らしてくる。"
+    "flavor": "暗闇の中で発光する、微小だが切れない興味の粒子。今ここを未来から照らしてくる。",
+    "flavor_en": "A minute yet unbreakable particle of interest, luminescent within the darkness. It illuminates the here and now from the future."
   },
   {
     "name": "絶望",
     "reading": "ぜつぼう",
     "english": "despair",
     "weight": 0.7,
-    "flavor": "希望の対極に位置する、深淵の興味の粒子。底まで沈むことで反転の合図を放つ。"
+    "flavor": "希望の対極に位置する、深淵の興味の粒子。底まで沈むことで反転の合図を放つ。",
+    "flavor_en": "A particle of abyssal interest, positioned opposite to hope. By sinking to the bottom, it emits the signal of reversal."
   },
   {
     "name": "正義",
     "reading": "せいぎ",
     "english": "justice",
     "weight": 1.0,
-    "flavor": "誰の視点に立つかで形が変わる、揺らぐ興味の粒子。問い続ける姿勢こそが本質となる。"
+    "flavor": "誰の視点に立つかで形が変わる、揺らぐ興味の粒子。問い続ける姿勢こそが本質となる。",
+    "flavor_en": "A wavering particle of interest whose form shifts with whose viewpoint one assumes. The posture of ceaseless questioning is its true essence."
   },
   {
     "name": "知恵",
     "reading": "ちえ",
     "english": "wisdom",
     "weight": 1.0,
-    "flavor": "知識を経験で炊き上げた、滋養ある興味の粒子。本ではなく沈黙の中で熟成される。"
+    "flavor": "知識を経験で炊き上げた、滋養ある興味の粒子。本ではなく沈黙の中で熟成される。",
+    "flavor_en": "A nourishing particle of interest, knowledge slow-cooked through experience. It matures not in books but within silence."
   },
   {
     "name": "力",
     "reading": "ちから",
     "english": "power",
     "weight": 1.0,
-    "flavor": "意志と物質を結ぶ、媒介の興味を宿す粒子。向きを誤れば破壊、定めれば創造となる。"
+    "flavor": "意志と物質を結ぶ、媒介の興味を宿す粒子。向きを誤れば破壊、定めれば創造となる。",
+    "flavor_en": "A particle bearing the interest of mediation, binding will to matter. Misdirected it becomes destruction; aimed true, creation."
   },
   {
     "name": "平和",
     "reading": "へいわ",
     "english": "peace",
     "weight": 1.0,
-    "flavor": "騒がしさが収まった後に立ち上る、繊細な興味の粒子。維持するほうが手に入れるより難しい。"
+    "flavor": "騒がしさが収まった後に立ち上る、繊細な興味の粒子。維持するほうが手に入れるより難しい。",
+    "flavor_en": "A delicate particle of interest, rising after the clamor subsides. It is harder to sustain than to attain."
   },
   {
     "name": "調和",
     "reading": "ちょうわ",
     "english": "harmony",
     "weight": 1.0,
-    "flavor": "違うものが共存する音、橋渡しの興味を宿す粒子。同質ではなく差異の中にこそ宿る。"
+    "flavor": "違うものが共存する音、橋渡しの興味を宿す粒子。同質ではなく差異の中にこそ宿る。",
+    "flavor_en": "A particle bearing the interest of mediation, the sound of differing things coexisting. It dwells not in sameness but within difference itself."
   },
   {
     "name": "混沌",
     "reading": "こんとん",
     "english": "chaos",
     "weight": 0.6,
-    "flavor": "秩序が生まれる前の母なる海、創発の興味の粒子。曖昧さが新しい形を孕んでいく。"
+    "flavor": "秩序が生まれる前の母なる海、創発の興味の粒子。曖昧さが新しい形を孕んでいく。",
+    "flavor_en": "A particle of emergent interest, the maternal sea before order is born. Within its ambiguity, new forms are conceived."
   },
   {
     "name": "秩序",
     "reading": "ちつじょ",
     "english": "order",
     "weight": 0.8,
-    "flavor": "混沌に意味の梁を渡す、構造の興味を宿す粒子。維持するための摩擦も常に伴う。"
+    "flavor": "混沌に意味の梁を渡す、構造の興味を宿す粒子。維持するための摩擦も常に伴う。",
+    "flavor_en": "A particle bearing the interest of structure, laying beams of meaning across chaos. Its maintenance always entails friction."
   },
   {
     "name": "真実",
     "reading": "しんじつ",
     "english": "truth",
     "weight": 0.9,
-    "flavor": "観測者が変わっても変わらぬ核、誠実の興味の粒子。砕けても破片にもまだ宿る。"
+    "flavor": "観測者が変わっても変わらぬ核、誠実の興味の粒子。砕けても破片にもまだ宿る。",
+    "flavor_en": "A particle of sincere interest, a core unaltered though the observer changes. Even shattered, it still dwells within the fragments."
   },
   {
     "name": "嘘",
     "reading": "うそ",
     "english": "lie",
     "weight": 1.0,
-    "flavor": "本当と嘘の境界で揺れる、影の興味を宿す粒子。物語を駆動する燃料にもなれる。"
+    "flavor": "本当と嘘の境界で揺れる、影の興味を宿す粒子。物語を駆動する燃料にもなれる。",
+    "flavor_en": "A particle bearing the interest of shadow, wavering at the boundary between truth and falsehood. It can also serve as fuel that drives a narrative."
   },
   {
     "name": "運命",
     "reading": "うんめい",
     "english": "fate",
     "weight": 0.5,
-    "flavor": "選択と偶然の網目が描く模様、巨視の興味の粒子。後から振り返ると形が見えてくる。"
+    "flavor": "選択と偶然の網目が描く模様、巨視の興味の粒子。後から振り返ると形が見えてくる。",
+    "flavor_en": "A particle of macroscopic interest, a pattern woven by the lattice of choice and chance. Its form becomes visible only when looked back upon."
   },
   {
     "name": "奇跡",
     "reading": "きせき",
     "english": "miracle",
     "weight": 0.3,
-    "flavor": "確率が屈する瞬間に立ち会う、稀少な興味の粒子。日常の中にも紛れ込む小さな歓喜。"
+    "flavor": "確率が屈する瞬間に立ち会う、稀少な興味の粒子。日常の中にも紛れ込む小さな歓喜。",
+    "flavor_en": "A rare particle of interest, witnessing the moment when probability yields. A small rejoicing that slips even into everyday life."
   },
   {
     "name": "栄光",
     "reading": "えいこう",
     "english": "glory",
     "weight": 0.7,
-    "flavor": "結果が他者の眼差しを通して輝く、社会的興味の粒子。一瞬の光は影とともに長く残る。"
+    "flavor": "結果が他者の眼差しを通して輝く、社会的興味の粒子。一瞬の光は影とともに長く残る。",
+    "flavor_en": "A particle of social interest, where outcome shines through the gaze of others. A momentary light lingers long, accompanied by its shadow."
   },
   {
     "name": "屈辱",
     "reading": "くつじょく",
     "english": "humiliation",
     "weight": 0.8,
-    "flavor": "誇りが踏みにじられた跡に残る、痛みの興味を宿す粒子。再起の燃料になることもある。"
+    "flavor": "誇りが踏みにじられた跡に残る、痛みの興味を宿す粒子。再起の燃料になることもある。",
+    "flavor_en": "A particle bearing the interest of pain, remaining where pride has been trampled. It may also become the fuel for resurgence."
   },
   {
     "name": "喜び",
     "reading": "よろこび",
     "english": "joy",
     "weight": 1.0,
-    "flavor": "心拍と表情が同時に弾む、純粋な興味の粒子。分けるほどに総量が増す不思議な熱。"
+    "flavor": "心拍と表情が同時に弾む、純粋な興味の粒子。分けるほどに総量が増す不思議な熱。",
+    "flavor_en": "A pure particle of interest, where pulse and expression leap in unison. A curious warmth whose sum increases the more it is shared."
   },
   {
     "name": "悲しみ",
     "reading": "かなしみ",
     "english": "sadness",
     "weight": 1.0,
-    "flavor": "失った形の輪郭を撫でる、慰めの興味を宿す粒子。涙によって心が再構成されていく。"
+    "flavor": "失った形の輪郭を撫でる、慰めの興味を宿す粒子。涙によって心が再構成されていく。",
+    "flavor_en": "A particle bearing the interest of solace, tracing the outline of what was lost. Through tears, the heart is gradually reconstituted."
   },
   {
     "name": "怒り",
     "reading": "いかり",
     "english": "anger",
     "weight": 1.0,
-    "flavor": "境界線が破られた合図、防衛の興味を宿す粒子。鎮める術を持つ者にこそ宿る力。"
+    "flavor": "境界線が破られた合図、防衛の興味を宿す粒子。鎮める術を持つ者にこそ宿る力。",
+    "flavor_en": "A particle bearing the interest of defense, the signal that a boundary has been breached. A power that dwells only in those who possess the art to quell it."
   },
   {
     "name": "恐怖",
     "reading": "きょうふ",
     "english": "fear",
     "weight": 1.0,
-    "flavor": "未知に対する身体の先回り、警戒の興味を宿す粒子。理解できれば力に変換できる。"
+    "flavor": "未知に対する身体の先回り、警戒の興味を宿す粒子。理解できれば力に変換できる。",
+    "flavor_en": "A particle bearing the interest of vigilance, the body's foreshadowing of the unknown. Once understood, it can be converted into power."
   },
   {
     "name": "安心",
     "reading": "あんしん",
     "english": "relief",
     "weight": 1.0,
-    "flavor": "緊張が解けた身体に流れ込む、ぬるい興味の粒子。深い呼吸が出来ることが証となる。"
+    "flavor": "緊張が解けた身体に流れ込む、ぬるい興味の粒子。深い呼吸が出来ることが証となる。",
+    "flavor_en": "A lukewarm particle of interest, flowing into the body once tension dissolves. A deep breath becomes its proof."
   },
   {
     "name": "孤独",
     "reading": "こどく",
     "english": "loneliness",
     "weight": 0.9,
-    "flavor": "他者がいない時間に自分と出会う、内省の興味の粒子。深さは他者と分かち合う器を作る。"
+    "flavor": "他者がいない時間に自分と出会う、内省の興味の粒子。深さは他者と分かち合う器を作る。",
+    "flavor_en": "A particle of introspective interest, meeting oneself in the absence of others. Its depth shapes the vessel that will be shared with others."
   },
   {
     "name": "友情",
     "reading": "ゆうじょう",
     "english": "friendship",
     "weight": 1.0,
-    "flavor": "対等な眼差しを交わし合う、共鳴の興味を宿す粒子。沈黙さえ言葉として通じ合う関係。"
+    "flavor": "対等な眼差しを交わし合う、共鳴の興味を宿す粒子。沈黙さえ言葉として通じ合う関係。",
+    "flavor_en": "A particle bearing the interest of resonance, exchanging gazes of equal standing. A bond in which even silence is understood as language."
   },
   {
     "name": "信頼",
     "reading": "しんらい",
     "english": "trust",
     "weight": 1.0,
-    "flavor": "未来を相手に預ける、緩やかで強い興味の粒子。築くのは年月、壊すのは一瞬となる。"
+    "flavor": "未来を相手に預ける、緩やかで強い興味の粒子。築くのは年月、壊すのは一瞬となる。",
+    "flavor_en": "A gentle yet potent particle of interest, entrusting the future to another. Years to build, an instant to shatter."
   },
   {
     "name": "裏切り",
     "reading": "うらぎり",
     "english": "betrayal",
     "weight": 0.7,
-    "flavor": "築かれた信頼に走る亀裂、痛烈な興味の粒子。傷の形が世界の輪郭を再定義する。"
+    "flavor": "築かれた信頼に走る亀裂、痛烈な興味の粒子。傷の形が世界の輪郭を再定義する。",
+    "flavor_en": "A piercing particle of interest, a fissure running through trust once built. The shape of the wound redefines the outline of the world."
   },
   {
     "name": "魂",
     "reading": "たましい",
     "english": "soul",
     "weight": 0.6,
-    "flavor": "肉体を脱いでも残るかもしれない、形なき興味の粒子。観測できないが確かに在るもの。"
+    "flavor": "肉体を脱いでも残るかもしれない、形なき興味の粒子。観測できないが確かに在るもの。",
+    "flavor_en": "A formless particle of interest, that may yet remain when the flesh is shed. Something that cannot be observed, yet assuredly exists."
   },
   {
     "name": "精神",
     "reading": "せいしん",
     "english": "spirit",
     "weight": 0.8,
-    "flavor": "肉体を統べる司令塔、意識の興味を宿す粒子。鍛えれば現実をも書き換える力となる。"
+    "flavor": "肉体を統べる司令塔、意識の興味を宿す粒子。鍛えれば現実をも書き換える力となる。",
+    "flavor_en": "A particle bearing the interest of consciousness, the command tower that governs the body. Tempered, it becomes a force that can rewrite reality itself."
   },
   {
     "name": "意志",
     "reading": "いし",
     "english": "will",
     "weight": 0.9,
-    "flavor": "未来を現在へ手繰り寄せる、推進の興味の粒子。折れない強さよりしなる強さが本質。"
+    "flavor": "未来を現在へ手繰り寄せる、推進の興味の粒子。折れない強さよりしなる強さが本質。",
+    "flavor_en": "A particle of propulsive interest, drawing the future toward the present. Its essence lies not in unbreakable strength but in supple resilience."
   },
   {
     "name": "欲望",
     "reading": "よくぼう",
     "english": "desire",
     "weight": 0.8,
-    "flavor": "存在を駆動する燃料、原動の興味を宿す粒子。手綱を握れば翼となり離せば荒馬となる。"
+    "flavor": "存在を駆動する燃料、原動の興味を宿す粒子。手綱を握れば翼となり離せば荒馬となる。",
+    "flavor_en": "A particle bearing the interest of primal drive, the fuel that propels existence. Held by the reins it becomes wings; released, a wild horse."
   },
   {
     "name": "理性",
     "reading": "りせい",
     "english": "reason",
     "weight": 0.8,
-    "flavor": "感情の波を観測する灯台、観測の興味を宿す粒子。冷たさではなく明晰さが本質となる。"
+    "flavor": "感情の波を観測する灯台、観測の興味を宿す粒子。冷たさではなく明晰さが本質となる。",
+    "flavor_en": "A particle bearing the interest of observation, a lighthouse observing the waves of emotion. Its essence is not coldness but clarity."
   },
   {
     "name": "本能",
     "reading": "ほんのう",
     "english": "instinct",
     "weight": 0.9,
-    "flavor": "言葉以前から身体に住む、古層の興味を宿す粒子。理屈を越えて命の判断を下してくる。"
+    "flavor": "言葉以前から身体に住む、古層の興味を宿す粒子。理屈を越えて命の判断を下してくる。",
+    "flavor_en": "A particle bearing the interest of ancient strata, dwelling in the body since before language. It renders the judgment of life beyond all logic."
   },
   {
     "name": "永遠",
     "reading": "えいえん",
     "english": "eternity",
     "weight": 0.4,
-    "flavor": "終わりを持たぬ広がり、無限の興味を宿す粒子。一瞬の中にも畳まれて宿ることがある。"
+    "flavor": "終わりを持たぬ広がり、無限の興味を宿す粒子。一瞬の中にも畳まれて宿ることがある。",
+    "flavor_en": "A particle bearing the interest of the infinite, an expanse possessing no end. It may at times be folded and contained within a single instant."
   },
   {
     "name": "刹那",
     "reading": "せつな",
     "english": "moment",
     "weight": 0.7,
-    "flavor": "切り取れぬほど短い時間の名、稀少な興味の粒子。集中の中でだけ可視化される時間。"
+    "flavor": "切り取れぬほど短い時間の名、稀少な興味の粒子。集中の中でだけ可視化される時間。",
+    "flavor_en": "A rare particle of interest, the name for a span of time too brief to be excised. A duration made visible only within concentration."
   },
   {
     "name": "無限",
     "reading": "むげん",
     "english": "infinity",
     "weight": 0.3,
-    "flavor": "終わりが定義されないことの自由、開放の興味の粒子。数字を超えた概念の海となる。"
+    "flavor": "終わりが定義されないことの自由、開放の興味の粒子。数字を超えた概念の海となる。",
+    "flavor_en": "A particle of liberating interest, the freedom of having no defined end. It becomes a conceptual ocean that transcends mere number."
   },
   {
     "name": "虚無",
     "reading": "きょむ",
     "english": "nothingness",
     "weight": 0.2,
-    "flavor": "全てが消えた後に立つ広がり、静寂の興味の粒子。無こそ最大の容器だと囁いてくる。"
+    "flavor": "全てが消えた後に立つ広がり、静寂の興味の粒子。無こそ最大の容器だと囁いてくる。",
+    "flavor_en": "A particle of silent interest, the expanse that stands once all has vanished. It whispers that nothingness itself is the greatest vessel."
   },
   {
     "name": "存在",
     "reading": "そんざい",
     "english": "existence",
     "weight": 0.6,
-    "flavor": "「在る」という最も基本的な事実、根源の興味の粒子。ここに在ること自体が奇跡。"
+    "flavor": "「在る」という最も基本的な事実、根源の興味の粒子。ここに在ること自体が奇跡。",
+    "flavor_en": "A particle of foundational interest, the most basic fact of \"being.\" To be here at all is itself a miracle."
   },
   {
     "name": "創造",
     "reading": "そうぞう",
     "english": "creation",
     "weight": 0.5,
-    "flavor": "無から有を立ち上げる、火花のような興味の粒子。観測者を作り手に変える瞬間の輝き。"
+    "flavor": "無から有を立ち上げる、火花のような興味の粒子。観測者を作り手に変える瞬間の輝き。",
+    "flavor_en": "A spark-like particle of interest, raising being from nonbeing. The radiance of the moment that transforms the observer into the maker."
   },
   {
     "name": "破壊",
     "reading": "はかい",
     "english": "destruction",
     "weight": 0.6,
-    "flavor": "形を解いて素材へ戻す、解体の興味を宿す粒子。次の創造のための余白を空けていく。"
+    "flavor": "形を解いて素材へ戻す、解体の興味を宿す粒子。次の創造のための余白を空けていく。",
+    "flavor_en": "A particle bearing the interest of dismantling, dissolving form back into material. It clears the blank space for the next creation."
   },
   {
     "name": "生命",
     "reading": "せいめい",
     "english": "life",
     "weight": 0.7,
-    "flavor": "情報が温度を持って動き続ける、奇跡の興味の粒子。一秒の継続が宇宙最大の事件となる。"
+    "flavor": "情報が温度を持って動き続ける、奇跡の興味の粒子。一秒の継続が宇宙最大の事件となる。",
+    "flavor_en": "A miraculous particle of interest, information continuing to move with warmth. Its continuance for a single second is the universe's greatest event."
   },
   {
     "name": "死",
     "reading": "し",
     "english": "death",
     "weight": 0.5,
-    "flavor": "形ある全てに必ず約束された、境界の興味の粒子。怖れる対象であり指針でもある。"
+    "flavor": "形ある全てに必ず約束された、境界の興味の粒子。怖れる対象であり指針でもある。",
+    "flavor_en": "A particle of liminal interest, promised without fail to all that holds form. An object of dread, yet also a guiding compass."
   },
   {
     "name": "再生",
     "reading": "さいせい",
     "english": "rebirth",
     "weight": 0.4,
-    "flavor": "終わったはずの形が再び芽吹く、循環の興味を宿す粒子。死を栄養に変える生命の知恵。"
+    "flavor": "終わったはずの形が再び芽吹く、循環の興味を宿す粒子。死を栄養に変える生命の知恵。",
+    "flavor_en": "A particle bearing the interest of cycles, where a form supposedly ended buds forth once more. The wisdom of life that transmutes death into nourishment."
   },
   {
     "name": "記憶",
     "reading": "きおく",
     "english": "memory",
     "weight": 0.9,
-    "flavor": "過去を未来へ運ぶ薄膜、橋渡しの興味を宿す粒子。歪みながらも自分の輪郭を保つ礎。"
+    "flavor": "過去を未来へ運ぶ薄膜、橋渡しの興味を宿す粒子。歪みながらも自分の輪郭を保つ礎。",
+    "flavor_en": "A particle bearing the interest of mediation, a thin membrane that conveys the past into the future. The foundation that preserves one's outline even as it warps."
   },
   {
     "name": "忘却",
     "reading": "ぼうきゃく",
     "english": "oblivion",
     "weight": 0.6,
-    "flavor": "心を軽くする慈悲、空白の興味を宿す粒子。覚え続けるためには手放しもまた必要。"
+    "flavor": "心を軽くする慈悲、空白の興味を宿す粒子。覚え続けるためには手放しもまた必要。",
+    "flavor_en": "A particle bearing the interest of blankness, a mercy that lightens the heart. To continue remembering, one must also learn to release."
   },
   {
     "name": "時",
     "reading": "とき",
     "english": "time",
     "weight": 0.5,
-    "flavor": "戻れない方向に流れる、不可逆の興味の粒子。観測することで形を変えてしまう存在。"
+    "flavor": "戻れない方向に流れる、不可逆の興味の粒子。観測することで形を変えてしまう存在。",
+    "flavor_en": "A particle of irreversible interest, flowing in a direction from which there is no return. An existence whose very form alters by being observed."
   },
   {
     "name": "空",
     "reading": "くう",
     "english": "void",
     "weight": 0.4,
-    "flavor": "全てが在りつつ全てが空である、逆説の興味の粒子。容れ物としての宇宙の名でもある。"
+    "flavor": "全てが在りつつ全てが空である、逆説の興味の粒子。容れ物としての宇宙の名でもある。",
+    "flavor_en": "A particle of paradoxical interest, where all exists and all is empty. It is also a name for the universe as a vessel."
   },
   {
     "name": "因果",
     "reading": "いんが",
     "english": "causality",
     "weight": 0.3,
-    "flavor": "原因と結果を結ぶ見えない糸、連鎖の興味の粒子。種を蒔く手の責任を静かに示す。"
+    "flavor": "原因と結果を結ぶ見えない糸、連鎖の興味の粒子。種を蒔く手の責任を静かに示す。",
+    "flavor_en": "A particle of linked interest, the invisible thread binding cause to effect. It quietly intimates the responsibility of the hand that sows the seed."
   },
   {
     "name": "輪廻",
     "reading": "りんね",
     "english": "samsara",
     "weight": 0.2,
-    "flavor": "終わらず巡り続ける円環、回帰の興味を宿す粒子。今日の行いが遥か先で実を結ぶ。"
+    "flavor": "終わらず巡り続ける円環、回帰の興味を宿す粒子。今日の行いが遥か先で実を結ぶ。",
+    "flavor_en": "A particle bearing the interest of recurrence, an unending ring that revolves on. Today's deed bears fruit in the distant beyond."
   },
   {
     "name": "時間",
     "reading": "じかん",
     "english": "time",
     "weight": 0.5,
-    "flavor": "万物を運ぶ目に見えぬ川、不可逆の興味を宿す粒子。観測する者だけが感じ取れる流れ。"
+    "flavor": "万物を運ぶ目に見えぬ川、不可逆の興味を宿す粒子。観測する者だけが感じ取れる流れ。",
+    "flavor_en": "A particle bearing the interest of irreversibility, an unseen river that conveys all things. A current perceptible only to the one who observes."
   },
   {
     "name": "空間",
     "reading": "くうかん",
     "english": "space",
     "weight": 0.5,
-    "flavor": "存在が広がる土台、容器の興味を宿す粒子。曲がり伸び縮みする現代の柔らかな概念。"
+    "flavor": "存在が広がる土台、容器の興味を宿す粒子。曲がり伸び縮みする現代の柔らかな概念。",
+    "flavor_en": "A particle bearing the interest of containment, the foundation upon which existence extends. A modern, supple concept that bends, stretches, and contracts."
   }
 ]

--- a/data/nouns/animals.json
+++ b/data/nouns/animals.json
@@ -4,461 +4,527 @@
     "reading": "さかな",
     "english": "fish",
     "weight": 1.0,
-    "flavor": "興味の海を泳ぐ、最も基本的な粒子。誰もが一度は惹かれる、普遍的な輝きを持つ。"
+    "flavor": "興味の海を泳ぐ、最も基本的な粒子。誰もが一度は惹かれる、普遍的な輝きを持つ。",
+    "flavor_en": "Swimming through the sea of curiosity, the most fundamental particle. Drawing everyone in at least once, with universal radiance."
   },
   {
     "name": "猫",
     "reading": "ねこ",
     "english": "cat",
     "weight": 1.0,
-    "flavor": "気まぐれな興味の化身。観測者の視線を、独立した軌道で躱す不思議な粒子。"
+    "flavor": "気まぐれな興味の化身。観測者の視線を、独立した軌道で躱す不思議な粒子。",
+    "flavor_en": "An incarnation of capricious interest. A mysterious particle that dodges the observer's gaze on its own independent orbit."
   },
   {
     "name": "犬",
     "reading": "いぬ",
     "english": "dog",
     "weight": 1.0,
-    "flavor": "忠実な興味を結晶化した粒子。離れていても主の心に共鳴し続ける。"
+    "flavor": "忠実な興味を結晶化した粒子。離れていても主の心に共鳴し続ける。",
+    "flavor_en": "A particle that crystallizes faithful interest. Resonating with its master's heart even from afar."
   },
   {
     "name": "鳥",
     "reading": "とり",
     "english": "bird",
     "weight": 1.0,
-    "flavor": "自由を意味する興味の翼。空という未踏領域へ意識を運ぶ伝令の粒子。"
+    "flavor": "自由を意味する興味の翼。空という未踏領域へ意識を運ぶ伝令の粒子。",
+    "flavor_en": "Wings of interest signifying freedom. A messenger particle that carries consciousness into the uncharted realm of the sky."
   },
   {
     "name": "龍",
     "reading": "りゅう",
     "english": "dragon",
     "weight": 0.1,
-    "flavor": "伝説の中毒性を秘めた、幻の粒子。一度見たら忘れられない、圧倒的な存在感を放つ。"
+    "flavor": "伝説の中毒性を秘めた、幻の粒子。一度見たら忘れられない、圧倒的な存在感を放つ。",
+    "flavor_en": "A phantom particle harboring the intoxication of legend. Once observed, never forgotten, radiating an overwhelming presence."
   },
   {
     "name": "鯨",
     "reading": "くじら",
     "english": "whale",
     "weight": 0.5,
-    "flavor": "海の底に眠る、巨大で穏やかな興味の粒子。深い知性の歌を響かせる。"
+    "flavor": "海の底に眠る、巨大で穏やかな興味の粒子。深い知性の歌を響かせる。",
+    "flavor_en": "A vast and gentle particle of interest slumbering in ocean depths. Resounding with the song of profound intelligence."
   },
   {
     "name": "蝶",
     "reading": "ちょう",
     "english": "butterfly",
     "weight": 1.0,
-    "flavor": "短命だが鮮烈な、変容を司る興味の粒子。儚さこそ美しさだと囁いてくる。"
+    "flavor": "短命だが鮮烈な、変容を司る興味の粒子。儚さこそ美しさだと囁いてくる。",
+    "flavor_en": "A brief yet vivid particle that presides over transformation. Whispering that ephemerality itself is beauty."
   },
   {
     "name": "蜘蛛",
     "reading": "くも",
     "english": "spider",
     "weight": 1.0,
-    "flavor": "見えない網で世界を編む、忍耐の興味を宿した粒子。観測の達人。"
+    "flavor": "見えない網で世界を編む、忍耐の興味を宿した粒子。観測の達人。",
+    "flavor_en": "A particle harboring patient interest, weaving the world with an invisible web. A master of observation."
   },
   {
     "name": "狼",
     "reading": "おおかみ",
     "english": "wolf",
     "weight": 0.7,
-    "flavor": "群れと孤独の両方を背負う、誇り高き興味の粒子。月夜に冴える鋭い精神。"
+    "flavor": "群れと孤独の両方を背負う、誇り高き興味の粒子。月夜に冴える鋭い精神。",
+    "flavor_en": "A proud particle of interest bearing both pack and solitude. A keen spirit sharpened beneath the moonlit night."
   },
   {
     "name": "熊",
     "reading": "くま",
     "english": "bear",
     "weight": 0.8,
-    "flavor": "ゆったりと深い興味を抱える、森の長老のような粒子。冬を越えてなお目覚める。"
+    "flavor": "ゆったりと深い興味を抱える、森の長老のような粒子。冬を越えてなお目覚める。",
+    "flavor_en": "A particle harboring leisurely, profound interest, like an elder of the forest. Awakening still after enduring winter."
   },
   {
     "name": "兎",
     "reading": "うさぎ",
     "english": "rabbit",
     "weight": 1.0,
-    "flavor": "跳ねるように湧き上がる、軽やかな興味の粒子。月の影を駆ける夢の住人。"
+    "flavor": "跳ねるように湧き上がる、軽やかな興味の粒子。月の影を駆ける夢の住人。",
+    "flavor_en": "A nimble particle of interest that springs up in leaps. A dweller of dreams that races across the lunar shadow."
   },
   {
     "name": "鹿",
     "reading": "しか",
     "english": "deer",
     "weight": 0.9,
-    "flavor": "静謐な森に生まれる、繊細で気品ある興味の粒子。視線が交わるだけで心が澄む。"
+    "flavor": "静謐な森に生まれる、繊細で気品ある興味の粒子。視線が交わるだけで心が澄む。",
+    "flavor_en": "A delicate, dignified particle of interest born in tranquil forests. The mere meeting of gazes brings clarity to the heart."
   },
   {
     "name": "虎",
     "reading": "とら",
     "english": "tiger",
     "weight": 0.5,
-    "flavor": "燃え盛る縞模様の、獰猛な興味を宿す粒子。一閃の集中が世界を切り裂く。"
+    "flavor": "燃え盛る縞模様の、獰猛な興味を宿す粒子。一閃の集中が世界を切り裂く。",
+    "flavor_en": "A particle harboring ferocious interest in blazing stripes. A single flash of focus cleaves through the world."
   },
   {
     "name": "象",
     "reading": "ぞう",
     "english": "elephant",
     "weight": 0.6,
-    "flavor": "巨大な記憶と緩やかな興味を運ぶ、大地に近しい粒子。決して忘れない瞳を持つ。"
+    "flavor": "巨大な記憶と緩やかな興味を運ぶ、大地に近しい粒子。決して忘れない瞳を持つ。",
+    "flavor_en": "A particle close to the earth, carrying vast memory and gentle interest. Bearing eyes that never forget."
   },
   {
     "name": "猿",
     "reading": "さる",
     "english": "monkey",
     "weight": 1.0,
-    "flavor": "好奇心そのものを擬人化したような、跳躍的な興味の粒子。世界に手を伸ばし続ける。"
+    "flavor": "好奇心そのものを擬人化したような、跳躍的な興味の粒子。世界に手を伸ばし続ける。",
+    "flavor_en": "A leaping particle of interest, as though curiosity itself were personified. Forever reaching out toward the world."
   },
   {
     "name": "馬",
     "reading": "うま",
     "english": "horse",
     "weight": 1.0,
-    "flavor": "風と並走する、疾駆する興味の粒子。蹄の音が新たな地平を切り開いていく。"
+    "flavor": "風と並走する、疾駆する興味の粒子。蹄の音が新たな地平を切り開いていく。",
+    "flavor_en": "A galloping particle of interest, running alongside the wind. The sound of hooves opens new horizons."
   },
   {
     "name": "蛇",
     "reading": "へび",
     "english": "snake",
     "weight": 1.0,
-    "flavor": "脱皮を繰り返す、再生の興味を司る粒子。冷たく賢く、地を這って真理に近づく。"
+    "flavor": "脱皮を繰り返す、再生の興味を司る粒子。冷たく賢く、地を這って真理に近づく。",
+    "flavor_en": "A particle presiding over the interest of rebirth, shedding skin again and again. Cold and wise, crawling along the earth toward truth."
   },
   {
     "name": "亀",
     "reading": "かめ",
     "english": "turtle",
     "weight": 1.0,
-    "flavor": "悠久の時間に寄り添う、辛抱強い興味の粒子。甲羅に星の数だけの記憶を刻む。"
+    "flavor": "悠久の時間に寄り添う、辛抱強い興味の粒子。甲羅に星の数だけの記憶を刻む。",
+    "flavor_en": "A patient particle of interest that abides with eternal time. Engraving as many memories as there are stars upon its shell."
   },
   {
     "name": "蛙",
     "reading": "かえる",
     "english": "frog",
     "weight": 1.0,
-    "flavor": "水と陸の境界に佇む、変態を象徴する興味の粒子。雨が降ると心が躍る。"
+    "flavor": "水と陸の境界に佇む、変態を象徴する興味の粒子。雨が降ると心が躍る。",
+    "flavor_en": "A particle of interest standing at the boundary of water and land, symbolizing metamorphosis. When the rain falls, its heart dances."
   },
   {
     "name": "鷲",
     "reading": "わし",
     "english": "eagle",
     "weight": 0.6,
-    "flavor": "高所から世界を俯瞰する、鋭利な興味の粒子。視野の広さが見識を磨いていく。"
+    "flavor": "高所から世界を俯瞰する、鋭利な興味の粒子。視野の広さが見識を磨いていく。",
+    "flavor_en": "A keen particle of interest that surveys the world from on high. The breadth of its vision hones its insight."
   },
   {
     "name": "鶴",
     "reading": "つる",
     "english": "crane",
     "weight": 0.7,
-    "flavor": "千年を生きるとされる、優雅さを宿した興味の粒子。羽ばたきが祝祭を運んでくる。"
+    "flavor": "千年を生きるとされる、優雅さを宿した興味の粒子。羽ばたきが祝祭を運んでくる。",
+    "flavor_en": "A particle of interest harboring elegance, said to live a thousand years. Its wingbeats bring forth celebration."
   },
   {
     "name": "狐",
     "reading": "きつね",
     "english": "fox",
     "weight": 0.9,
-    "flavor": "知恵と幻惑を兼ね備えた、悪戯好きな興味の粒子。真贋を見抜く瞳を持っている。"
+    "flavor": "知恵と幻惑を兼ね備えた、悪戯好きな興味の粒子。真贋を見抜く瞳を持っている。",
+    "flavor_en": "A mischievous particle of interest possessing both wisdom and illusion. Bearing eyes that discern the true from the false."
   },
   {
     "name": "狸",
     "reading": "たぬき",
     "english": "raccoon dog",
     "weight": 1.0,
-    "flavor": "化けることで真実を語る、ユーモラスな興味の粒子。腹鼓で世界の堅さを和らげる。"
+    "flavor": "化けることで真実を語る、ユーモラスな興味の粒子。腹鼓で世界の堅さを和らげる。",
+    "flavor_en": "A humorous particle of interest that speaks truth through transformation. Its belly-drum softens the rigidity of the world."
   },
   {
     "name": "鼠",
     "reading": "ねずみ",
     "english": "mouse",
     "weight": 1.0,
-    "flavor": "暗がりにこそ宿る、機敏な興味の粒子。隅々を駆け抜けては小さな発見を持ち帰る。"
+    "flavor": "暗がりにこそ宿る、機敏な興味の粒子。隅々を駆け抜けては小さな発見を持ち帰る。",
+    "flavor_en": "A nimble particle of interest that dwells precisely in the shadows. Racing through every corner, returning with small discoveries."
   },
   {
     "name": "蝙蝠",
     "reading": "こうもり",
     "english": "bat",
     "weight": 0.8,
-    "flavor": "光ではなく音で世界を識る、逆説的な興味の粒子。闇に響く声が地図を描く。"
+    "flavor": "光ではなく音で世界を識る、逆説的な興味の粒子。闇に響く声が地図を描く。",
+    "flavor_en": "A paradoxical particle of interest that perceives the world through sound rather than light. Voices echoing in darkness sketch the map."
   },
   {
     "name": "蝸牛",
     "reading": "かたつむり",
     "english": "snail",
     "weight": 1.0,
-    "flavor": "螺旋を背負い、緩慢に進む静かな興味の粒子。急がぬことこそ深さだと示してくれる。"
+    "flavor": "螺旋を背負い、緩慢に進む静かな興味の粒子。急がぬことこそ深さだと示してくれる。",
+    "flavor_en": "A quiet particle of interest advancing slowly, bearing a spiral upon its back. It shows us that depth lies in not hastening."
   },
   {
     "name": "蟻",
     "reading": "あり",
     "english": "ant",
     "weight": 1.0,
-    "flavor": "群体として知性を発揮する、勤勉な興味の粒子。一粒一粒が巨大な意志を形作る。"
+    "flavor": "群体として知性を発揮する、勤勉な興味の粒子。一粒一粒が巨大な意志を形作る。",
+    "flavor_en": "A diligent particle of interest that manifests intelligence as a colony. Each single grain forms a vast collective will."
   },
   {
     "name": "蜂",
     "reading": "はち",
     "english": "bee",
     "weight": 1.0,
-    "flavor": "甘さの探究者にして、規律ある興味の粒子。六角形の宇宙に未来を蓄えていく。"
+    "flavor": "甘さの探究者にして、規律ある興味の粒子。六角形の宇宙に未来を蓄えていく。",
+    "flavor_en": "A seeker of sweetness and a disciplined particle of interest. Storing the future within a hexagonal cosmos."
   },
   {
     "name": "蚊",
     "reading": "か",
     "english": "mosquito",
     "weight": 1.0,
-    "flavor": "些細だが鋭利な、執拗な興味の粒子。夜の静けさを破り、生の血脈を意識させる。"
+    "flavor": "些細だが鋭利な、執拗な興味の粒子。夜の静けさを破り、生の血脈を意識させる。",
+    "flavor_en": "A trivial yet sharp, persistent particle of interest. Breaking the silence of night, making one conscious of the pulse of life."
   },
   {
     "name": "鳳凰",
     "reading": "ほうおう",
     "english": "phoenix",
     "weight": 0.05,
-    "flavor": "灰から蘇る、再生の伝説を背負った稀少な粒子。出会えた者は新生の予兆を見る。"
+    "flavor": "灰から蘇る、再生の伝説を背負った稀少な粒子。出会えた者は新生の予兆を見る。",
+    "flavor_en": "A rare particle bearing the legend of rebirth, resurrected from ashes. Those who encounter it glimpse an omen of renewal."
   },
   {
     "name": "麒麟",
     "reading": "きりん",
     "english": "kirin",
     "weight": 0.08,
-    "flavor": "聖王の到来を告げる、瑞兆そのものの粒子。蹄は虫すらも踏まないと言われる。"
+    "flavor": "聖王の到来を告げる、瑞兆そのものの粒子。蹄は虫すらも踏まないと言われる。",
+    "flavor_en": "A particle that is an auspicious omen itself, heralding the arrival of a sage ruler. Its hooves are said to tread upon not even an insect."
   },
   {
     "name": "鯉",
     "reading": "こい",
     "english": "carp",
     "weight": 0.9,
-    "flavor": "滝を昇って龍となる伝承を抱く、向上心の粒子。波紋ひとつが運命を変えていく。"
+    "flavor": "滝を昇って龍となる伝承を抱く、向上心の粒子。波紋ひとつが運命を変えていく。",
+    "flavor_en": "A particle of aspiration embracing the legend of ascending the waterfall to become a dragon. A single ripple alters fate."
   },
   {
     "name": "鮫",
     "reading": "さめ",
     "english": "shark",
     "weight": 0.6,
-    "flavor": "止まれば沈む宿命を背負う、前進の興味を持つ粒子。鋭い嗅覚が真実を嗅ぎ分ける。"
+    "flavor": "止まれば沈む宿命を背負う、前進の興味を持つ粒子。鋭い嗅覚が真実を嗅ぎ分ける。",
+    "flavor_en": "A particle of forward-moving interest bearing the fate of sinking if it halts. Its sharp sense discerns the scent of truth."
   },
   {
     "name": "海豚",
     "reading": "いるか",
     "english": "dolphin",
     "weight": 0.7,
-    "flavor": "海中で歌い合う、社交的で知性に満ちた興味の粒子。波間に笑い声が響く。"
+    "flavor": "海中で歌い合う、社交的で知性に満ちた興味の粒子。波間に笑い声が響く。",
+    "flavor_en": "A sociable particle of interest filled with intelligence, singing to one another beneath the waves. Laughter resounds between the swells."
   },
   {
     "name": "章魚",
     "reading": "たこ",
     "english": "octopus",
     "weight": 0.8,
-    "flavor": "八本の腕で世界に触れる、好奇心の塊のような粒子。色を変えて感情を語る。"
+    "flavor": "八本の腕で世界に触れる、好奇心の塊のような粒子。色を変えて感情を語る。",
+    "flavor_en": "A particle like a cluster of curiosity, touching the world with eight arms. Speaking its emotions through changing colors."
   },
   {
     "name": "烏賊",
     "reading": "いか",
     "english": "squid",
     "weight": 0.8,
-    "flavor": "墨で輪郭を消す、戦略的な興味を宿す粒子。深海の暗闇に思考を漂わせる。"
+    "flavor": "墨で輪郭を消す、戦略的な興味を宿す粒子。深海の暗闇に思考を漂わせる。",
+    "flavor_en": "A particle harboring strategic interest, erasing its outline with ink. Letting its thoughts drift through the darkness of the deep sea."
   },
   {
     "name": "海月",
     "reading": "くらげ",
     "english": "jellyfish",
     "weight": 1.0,
-    "flavor": "形を持たぬまま漂う、透明な興味の粒子。生死の境すらやわらかく溶かしてしまう。"
+    "flavor": "形を持たぬまま漂う、透明な興味の粒子。生死の境すらやわらかく溶かしてしまう。",
+    "flavor_en": "A transparent particle of interest, drifting without form. Even the boundary between life and death is softly dissolved."
   },
   {
     "name": "海星",
     "reading": "ひとで",
     "english": "starfish",
     "weight": 1.0,
-    "flavor": "五芒の腕で海底を歩む、星座のような興味の粒子。ゆっくりと再生する忍耐の輝き。"
+    "flavor": "五芒の腕で海底を歩む、星座のような興味の粒子。ゆっくりと再生する忍耐の輝き。",
+    "flavor_en": "A constellation-like particle of interest, walking the seabed with five-pointed arms. A patient radiance that slowly regenerates."
   },
   {
     "name": "獅子",
     "reading": "しし",
     "english": "lion",
     "weight": 0.5,
-    "flavor": "百獣の王として君臨する、誇り高き興味の粒子。咆哮ひとつで群衆の心を統べる。"
+    "flavor": "百獣の王として君臨する、誇り高き興味の粒子。咆哮ひとつで群衆の心を統べる。",
+    "flavor_en": "A proud particle of interest that reigns as king of all beasts. A single roar governs the hearts of the multitude."
   },
   {
     "name": "豹",
     "reading": "ひょう",
     "english": "leopard",
     "weight": 0.6,
-    "flavor": "音もなく忍び寄る、研ぎ澄まされた興味の粒子。斑模様に世界の影を宿す。"
+    "flavor": "音もなく忍び寄る、研ぎ澄まされた興味の粒子。斑模様に世界の影を宿す。",
+    "flavor_en": "A honed particle of interest that creeps near without sound. The shadows of the world reside within its spotted pattern."
   },
   {
     "name": "豚",
     "reading": "ぶた",
     "english": "pig",
     "weight": 1.0,
-    "flavor": "豊かさと愛嬌を併せ持つ、丸みのある興味の粒子。賢さを愚かさで覆い隠す名手。"
+    "flavor": "豊かさと愛嬌を併せ持つ、丸みのある興味の粒子。賢さを愚かさで覆い隠す名手。",
+    "flavor_en": "A rounded particle of interest possessing both abundance and charm. A master at concealing wisdom beneath folly."
   },
   {
     "name": "牛",
     "reading": "うし",
     "english": "cow",
     "weight": 1.0,
-    "flavor": "大地を耕し続けてきた、忠実で力強い興味の粒子。咀嚼するように真理を反芻する。"
+    "flavor": "大地を耕し続けてきた、忠実で力強い興味の粒子。咀嚼するように真理を反芻する。",
+    "flavor_en": "A faithful and powerful particle of interest that has long tilled the earth. Ruminating upon truth as though chewing."
   },
   {
     "name": "羊",
     "reading": "ひつじ",
     "english": "sheep",
     "weight": 1.0,
-    "flavor": "群れに寄り添う、柔らかな興味の粒子。眠りの数を数えるたび世界が静かになる。"
+    "flavor": "群れに寄り添う、柔らかな興味の粒子。眠りの数を数えるたび世界が静かになる。",
+    "flavor_en": "A soft particle of interest that nestles within the flock. With each count of sleep, the world grows still."
   },
   {
     "name": "山羊",
     "reading": "やぎ",
     "english": "goat",
     "weight": 1.0,
-    "flavor": "崖を平然と歩む、孤高で気高い興味の粒子。瞳の横長い瞳孔は別世界を映す。"
+    "flavor": "崖を平然と歩む、孤高で気高い興味の粒子。瞳の横長い瞳孔は別世界を映す。",
+    "flavor_en": "A solitary and noble particle of interest that walks the cliffs with composure. Its horizontal pupils reflect another world."
   },
   {
     "name": "駱駝",
     "reading": "らくだ",
     "english": "camel",
     "weight": 0.7,
-    "flavor": "砂漠を渡る、忍耐そのもののような興味の粒子。背の瘤に未来の水を蓄えている。"
+    "flavor": "砂漠を渡る、忍耐そのもののような興味の粒子。背の瘤に未来の水を蓄えている。",
+    "flavor_en": "A particle of interest like patience itself, traversing the desert. Storing the water of the future within the hump upon its back."
   },
   {
     "name": "河馬",
     "reading": "かば",
     "english": "hippopotamus",
     "weight": 0.6,
-    "flavor": "水中に潜む、巨大で静かな興味の粒子。穏やかに見えて怒らせれば嵐を呼ぶ。"
+    "flavor": "水中に潜む、巨大で静かな興味の粒子。穏やかに見えて怒らせれば嵐を呼ぶ。",
+    "flavor_en": "A vast and silent particle of interest lurking beneath the water. Calm in appearance, yet summoning storms when angered."
   },
   {
     "name": "犀",
     "reading": "さい",
     "english": "rhinoceros",
     "weight": 0.5,
-    "flavor": "一本角に伝説を宿す、寡黙な興味の粒子。突進すれば常識すら砕けてしまう。"
+    "flavor": "一本角に伝説を宿す、寡黙な興味の粒子。突進すれば常識すら砕けてしまう。",
+    "flavor_en": "A taciturn particle of interest harboring legend within a single horn. When it charges, even common sense is shattered."
   },
   {
     "name": "鳩",
     "reading": "はと",
     "english": "pigeon",
     "weight": 1.0,
-    "flavor": "平和の象徴として宙を舞う、慎ましい興味の粒子。手紙を運び、距離を縮めていく。"
+    "flavor": "平和の象徴として宙を舞う、慎ましい興味の粒子。手紙を運び、距離を縮めていく。",
+    "flavor_en": "A modest particle of interest that dances through the air as a symbol of peace. Bearing letters, drawing distances closer."
   },
   {
     "name": "雀",
     "reading": "すずめ",
     "english": "sparrow",
     "weight": 1.0,
-    "flavor": "身近に潜む、賑やかな興味の粒子。朝の空気を細やかなさえずりで彩り続ける。"
+    "flavor": "身近に潜む、賑やかな興味の粒子。朝の空気を細やかなさえずりで彩り続ける。",
+    "flavor_en": "A lively particle of interest that lingers close at hand. Forever coloring the morning air with delicate chirping."
   },
   {
     "name": "鴉",
     "reading": "からす",
     "english": "crow",
     "weight": 1.0,
-    "flavor": "賢さの黒衣をまとう、神秘的な興味の粒子。鏡を覗くように自分の姿を理解する。"
+    "flavor": "賢さの黒衣をまとう、神秘的な興味の粒子。鏡を覗くように自分の姿を理解する。",
+    "flavor_en": "A mysterious particle of interest clad in the black robe of wisdom. Understanding its own form as though peering into a mirror."
   },
   {
     "name": "燕",
     "reading": "つばめ",
     "english": "swallow",
     "weight": 1.0,
-    "flavor": "春を運ぶ旅人として現れる、軽快な興味の粒子。軒先に幸福の予兆を巣作る。"
+    "flavor": "春を運ぶ旅人として現れる、軽快な興味の粒子。軒先に幸福の予兆を巣作る。",
+    "flavor_en": "A nimble particle of interest that appears as a traveler bearing spring. Building nests of happy omens beneath the eaves."
   },
   {
     "name": "鸚鵡",
     "reading": "おうむ",
     "english": "parrot",
     "weight": 0.7,
-    "flavor": "言葉を映す、模倣の興味を司る粒子。誰の声でも自分のものに変えてしまう才。"
+    "flavor": "言葉を映す、模倣の興味を司る粒子。誰の声でも自分のものに変えてしまう才。",
+    "flavor_en": "A particle presiding over the interest of mimicry, reflecting words. Possessing the talent to make any voice its own."
   },
   {
     "name": "梟",
     "reading": "ふくろう",
     "english": "owl",
     "weight": 0.8,
-    "flavor": "夜の知恵を司る、静謐な興味の粒子。首を巡らせて見えない世界を観測している。"
+    "flavor": "夜の知恵を司る、静謐な興味の粒子。首を巡らせて見えない世界を観測している。",
+    "flavor_en": "A tranquil particle of interest that presides over the wisdom of night. Turning its head to observe the unseen world."
   },
   {
     "name": "孔雀",
     "reading": "くじゃく",
     "english": "peacock",
     "weight": 0.4,
-    "flavor": "扇のような飾りを広げる、誇示の興味を宿す粒子。美しさは生存の戦略だと教える。"
+    "flavor": "扇のような飾りを広げる、誇示の興味を宿す粒子。美しさは生存の戦略だと教える。",
+    "flavor_en": "A particle harboring the interest of display, spreading its fan-like adornment. Teaching that beauty is a strategy of survival."
   },
   {
     "name": "鴨",
     "reading": "かも",
     "english": "duck",
     "weight": 1.0,
-    "flavor": "水に浮かびつつ足は休まぬ、忍耐の興味を持つ粒子。表面の優雅さの裏に努力あり。"
+    "flavor": "水に浮かびつつ足は休まぬ、忍耐の興味を持つ粒子。表面の優雅さの裏に努力あり。",
+    "flavor_en": "A particle of patient interest whose feet never rest while it floats upon the water. Behind surface grace lies ceaseless effort."
   },
   {
     "name": "白鳥",
     "reading": "はくちょう",
     "english": "swan",
     "weight": 0.6,
-    "flavor": "湖面に映る純白の興味、変身の伝説を抱く粒子。醜さを美に変える物語の主人公。"
+    "flavor": "湖面に映る純白の興味、変身の伝説を抱く粒子。醜さを美に変える物語の主人公。",
+    "flavor_en": "Pure white interest mirrored upon the lake, a particle embracing the legend of transformation. The protagonist of a tale that turns ugliness into beauty."
   },
   {
     "name": "蝉",
     "reading": "せみ",
     "english": "cicada",
     "weight": 1.0,
-    "flavor": "数年の地中生活を経て鳴く、短く濃密な興味の粒子。夏の終わりを告げる声。"
+    "flavor": "数年の地中生活を経て鳴く、短く濃密な興味の粒子。夏の終わりを告げる声。",
+    "flavor_en": "A brief yet dense particle of interest that cries after years beneath the earth. A voice heralding the end of summer."
   },
   {
     "name": "蜻蛉",
     "reading": "とんぼ",
     "english": "dragonfly",
     "weight": 1.0,
-    "flavor": "停空飛行で時間を切り取る、繊細な興味の粒子。複眼が世界の無数の真実を映す。"
+    "flavor": "停空飛行で時間を切り取る、繊細な興味の粒子。複眼が世界の無数の真実を映す。",
+    "flavor_en": "A delicate particle of interest that cuts out time through hovering flight. Compound eyes reflecting innumerable truths of the world."
   },
   {
     "name": "螢",
     "reading": "ほたる",
     "english": "firefly",
     "weight": 0.7,
-    "flavor": "短い夜にだけ灯る、儚くも鮮烈な興味の粒子。光は呼吸のように明滅していく。"
+    "flavor": "短い夜にだけ灯る、儚くも鮮烈な興味の粒子。光は呼吸のように明滅していく。",
+    "flavor_en": "An ephemeral yet vivid particle of interest, kindled only in brief nights. Its light flickers like breathing."
   },
   {
     "name": "蛾",
     "reading": "が",
     "english": "moth",
     "weight": 1.0,
-    "flavor": "光に焼かれることも厭わぬ、執着の興味を宿す粒子。夜の蝶として静かに舞う。"
+    "flavor": "光に焼かれることも厭わぬ、執着の興味を宿す粒子。夜の蝶として静かに舞う。",
+    "flavor_en": "A particle harboring the interest of attachment, unafraid even of being scorched by light. Dancing silently as a butterfly of night."
   },
   {
     "name": "甲虫",
     "reading": "かぶとむし",
     "english": "beetle",
     "weight": 0.8,
-    "flavor": "鎧をまとった、堅実で勇猛な興味の粒子。子どもの宝石箱の常連でもある。"
+    "flavor": "鎧をまとった、堅実で勇猛な興味の粒子。子どもの宝石箱の常連でもある。",
+    "flavor_en": "A steadfast and valiant particle of interest, clad in armor. Also a regular within the jewel boxes of children."
   },
   {
     "name": "蟷螂",
     "reading": "かまきり",
     "english": "mantis",
     "weight": 0.9,
-    "flavor": "祈るような前肢を持つ、冷静な狩人の興味を宿す粒子。捕食すら儀式に変える。"
+    "flavor": "祈るような前肢を持つ、冷静な狩人の興味を宿す粒子。捕食すら儀式に変える。",
+    "flavor_en": "A particle harboring the interest of a composed hunter, bearing forelimbs that seem to pray. Transforming even predation into ritual."
   },
   {
     "name": "蝗",
     "reading": "ばった",
     "english": "grasshopper",
     "weight": 1.0,
-    "flavor": "群れて空を覆う、爆発的な興味の粒子。豊穣と災厄の境界線上を跳び続ける。"
+    "flavor": "群れて空を覆う、爆発的な興味の粒子。豊穣と災厄の境界線上を跳び続ける。",
+    "flavor_en": "An explosive particle of interest that swarms and veils the sky. Forever leaping upon the boundary between abundance and calamity."
   },
   {
     "name": "蠍",
     "reading": "さそり",
     "english": "scorpion",
     "weight": 0.6,
-    "flavor": "尾に毒を秘めた、孤高で防衛的な興味の粒子。星座にもなり夜空を護っている。"
+    "flavor": "尾に毒を秘めた、孤高で防衛的な興味の粒子。星座にもなり夜空を護っている。",
+    "flavor_en": "A solitary and defensive particle of interest, harboring venom in its tail. Becoming a constellation as well, guarding the night sky."
   },
   {
     "name": "蟹",
     "reading": "かに",
     "english": "crab",
     "weight": 1.0,
-    "flavor": "横歩きで世界に挑む、頑なな興味の粒子。鋏は守りであり挨拶でもある。"
+    "flavor": "横歩きで世界に挑む、頑なな興味の粒子。鋏は守りであり挨拶でもある。",
+    "flavor_en": "A stubborn particle of interest that confronts the world with a sideways gait. Its claws are both defense and greeting."
   },
   {
     "name": "海老",
     "reading": "えび",
     "english": "shrimp",
     "weight": 1.0,
-    "flavor": "古から保たれた姿で深海を生きる、長寿の興味を宿す粒子。脱皮で若返り続ける。"
+    "flavor": "古から保たれた姿で深海を生きる、長寿の興味を宿す粒子。脱皮で若返り続ける。",
+    "flavor_en": "A particle harboring the interest of longevity, dwelling in the deep sea in a form preserved since antiquity. Renewing its youth through molting."
   }
 ]

--- a/data/nouns/colors.json
+++ b/data/nouns/colors.json
@@ -4,174 +4,199 @@
     "reading": "あか",
     "english": "red",
     "weight": 1.0,
-    "flavor": "情熱と血潮を象徴する、最も原初的な興味の粒子。心拍数を上げる根源の輝き。"
+    "flavor": "情熱と血潮を象徴する、最も原初的な興味の粒子。心拍数を上げる根源の輝き。",
+    "flavor_en": "The most primal particle of curiosity, symbolizing passion and lifeblood. A primordial radiance that quickens the heartbeat."
   },
   {
     "name": "青",
     "reading": "あお",
     "english": "blue",
     "weight": 1.0,
-    "flavor": "海と空を映す、無限と冷静さの興味を宿す粒子。深さは見る者の心を試す。"
+    "flavor": "海と空を映す、無限と冷静さの興味を宿す粒子。深さは見る者の心を試す。",
+    "flavor_en": "A particle reflecting sea and sky, harboring the curiosity of infinity and composure. Its depth tests the heart of the observer."
   },
   {
     "name": "緑",
     "reading": "みどり",
     "english": "green",
     "weight": 1.0,
-    "flavor": "生命と循環の興味を司る、安らぎの粒子。視界に入るだけで脳が呼吸を整える。"
+    "flavor": "生命と循環の興味を司る、安らぎの粒子。視界に入るだけで脳が呼吸を整える。",
+    "flavor_en": "A particle of tranquility presiding over the curiosity of life and cycle. Its mere presence in sight steadies the breath of the mind."
   },
   {
     "name": "黄",
     "reading": "き",
     "english": "yellow",
     "weight": 1.0,
-    "flavor": "光と注意を呼び寄せる、警戒と歓喜の興味の粒子。世界を一瞬で明るく塗り替える。"
+    "flavor": "光と注意を呼び寄せる、警戒と歓喜の興味の粒子。世界を一瞬で明るく塗り替える。",
+    "flavor_en": "A particle of curiosity summoning light and attention, alert and jubilant. It repaints the world bright in an instant."
   },
   {
     "name": "紫",
     "reading": "むらさき",
     "english": "purple",
     "weight": 1.0,
-    "flavor": "高貴と神秘の境界に佇む、内省的な興味の粒子。古代では王だけが纏えた色。"
+    "flavor": "高貴と神秘の境界に佇む、内省的な興味の粒子。古代では王だけが纏えた色。",
+    "flavor_en": "An introspective particle of curiosity dwelling at the border of nobility and mystery. A hue once worn by kings alone."
   },
   {
     "name": "橙",
     "reading": "だいだい",
     "english": "orange",
     "weight": 1.0,
-    "flavor": "夕焼けと果実を兼ねた、温かな興味の粒子。境界の時間に最も濃く立ち昇る。"
+    "flavor": "夕焼けと果実を兼ねた、温かな興味の粒子。境界の時間に最も濃く立ち昇る。",
+    "flavor_en": "A warm particle of curiosity, both sunset and fruit. It rises most thickly in the threshold hours."
   },
   {
     "name": "桃",
     "reading": "もも",
     "english": "pink",
     "weight": 1.0,
-    "flavor": "やわらかな朝の光をまとう、優しい興味の粒子。心を解きほぐす最初の挨拶。"
+    "flavor": "やわらかな朝の光をまとう、優しい興味の粒子。心を解きほぐす最初の挨拶。",
+    "flavor_en": "A gentle particle of curiosity clothed in the soft light of morning. The first greeting that loosens the heart."
   },
   {
     "name": "水",
     "reading": "みず",
     "english": "cyan",
     "weight": 1.0,
-    "flavor": "透き通る空気のような、清涼な興味の粒子。視線が抜けていく軽さを携える。"
+    "flavor": "透き通る空気のような、清涼な興味の粒子。視線が抜けていく軽さを携える。",
+    "flavor_en": "A cool, clear particle of curiosity, like translucent air. It carries the lightness through which the gaze passes unhindered."
   },
   {
     "name": "紺",
     "reading": "こん",
     "english": "navy",
     "weight": 1.0,
-    "flavor": "夜明け前の深さを宿す、静謐な興味の粒子。船乗りを導いてきた航海の色。"
+    "flavor": "夜明け前の深さを宿す、静謐な興味の粒子。船乗りを導いてきた航海の色。",
+    "flavor_en": "A serene particle of curiosity holding the depth of pre-dawn. The voyaging hue that has guided sailors through the ages."
   },
   {
     "name": "茶",
     "reading": "ちゃ",
     "english": "brown",
     "weight": 1.0,
-    "flavor": "大地と樹皮を映す、安定の興味を宿す粒子。生活の身近さを丁寧に色づける。"
+    "flavor": "大地と樹皮を映す、安定の興味を宿す粒子。生活の身近さを丁寧に色づける。",
+    "flavor_en": "A particle of steady curiosity mirroring earth and bark. It tints the nearness of daily life with quiet care."
   },
   {
     "name": "灰",
     "reading": "はい",
     "english": "gray",
     "weight": 1.0,
-    "flavor": "黒と白の間で揺らぐ、中庸な興味の粒子。沈黙にも雄弁にもなれる柔軟さを持つ。"
+    "flavor": "黒と白の間で揺らぐ、中庸な興味の粒子。沈黙にも雄弁にもなれる柔軟さを持つ。",
+    "flavor_en": "A temperate particle of curiosity wavering between black and white. It holds the suppleness to be silent or eloquent at will."
   },
   {
     "name": "銀",
     "reading": "ぎん",
     "english": "silver",
     "weight": 0.5,
-    "flavor": "月の光を写し取る、冷ややかな興味の粒子。時間を経るほど落ち着いた風格を増す。"
+    "flavor": "月の光を写し取る、冷ややかな興味の粒子。時間を経るほど落ち着いた風格を増す。",
+    "flavor_en": "A cool particle of curiosity that transcribes the light of the moon. The longer time passes, the deeper its quiet dignity grows."
   },
   {
     "name": "金",
     "reading": "きん",
     "english": "gold",
     "weight": 0.3,
-    "flavor": "永遠を象徴する、栄華の興味を宿した粒子。錆びぬ輝きが価値そのものを定義する。"
+    "flavor": "永遠を象徴する、栄華の興味を宿した粒子。錆びぬ輝きが価値そのものを定義する。",
+    "flavor_en": "A particle harboring the curiosity of splendor, symbol of eternity. Its untarnished radiance defines the very meaning of value."
   },
   {
     "name": "白",
     "reading": "しろ",
     "english": "white",
     "weight": 1.0,
-    "flavor": "全ての色を包含する、純粋な興味の粒子。始まりにも終わりにも宿る神聖な色。"
+    "flavor": "全ての色を包含する、純粋な興味の粒子。始まりにも終わりにも宿る神聖な色。",
+    "flavor_en": "A pure particle of curiosity that contains all colors within. A sacred hue dwelling in both the beginning and the end."
   },
   {
     "name": "黒",
     "reading": "くろ",
     "english": "black",
     "weight": 1.0,
-    "flavor": "全ての色を吸い込む、深淵の興味を宿す粒子。闇は無ではなく可能性の容器だ。"
+    "flavor": "全ての色を吸い込む、深淵の興味を宿す粒子。闇は無ではなく可能性の容器だ。",
+    "flavor_en": "A particle of abyssal curiosity that drinks in all colors. Darkness is not absence, but a vessel of possibility."
   },
   {
     "name": "藍",
     "reading": "あい",
     "english": "indigo",
     "weight": 0.8,
-    "flavor": "夜と海の境界を染める、深い興味の粒子。日本の青を象徴する伝統の彩り。"
+    "flavor": "夜と海の境界を染める、深い興味の粒子。日本の青を象徴する伝統の彩り。",
+    "flavor_en": "A deep particle of curiosity that dyes the border of night and sea. The traditional hue that embodies the blue of Japan."
   },
   {
     "name": "朱",
     "reading": "しゅ",
     "english": "vermilion",
     "weight": 0.7,
-    "flavor": "鳥居と魔除けに用いられた、霊力の興味を宿す粒子。境界線を引き直す赤の聖。"
+    "flavor": "鳥居と魔除けに用いられた、霊力の興味を宿す粒子。境界線を引き直す赤の聖。",
+    "flavor_en": "A particle of spiritual curiosity, used in torii gates and wards against evil. A sacred red that redraws the lines of boundary."
   },
   {
     "name": "翠",
     "reading": "みどり",
     "english": "jade green",
     "weight": 0.6,
-    "flavor": "翡翠のような清冽な緑、希望の興味を宿す粒子。雨後の若葉に最も近い色合い。"
+    "flavor": "翡翠のような清冽な緑、希望の興味を宿す粒子。雨後の若葉に最も近い色合い。",
+    "flavor_en": "A clear, jade-bright green particle harboring the curiosity of hope. The hue nearest to young leaves after the rain."
   },
   {
     "name": "碧",
     "reading": "へき",
     "english": "azure",
     "weight": 0.5,
-    "flavor": "深い海と空に共通する、悠久の興味を宿す粒子。眺めるたびに視野が広がっていく。"
+    "flavor": "深い海と空に共通する、悠久の興味を宿す粒子。眺めるたびに視野が広がっていく。",
+    "flavor_en": "A particle of timeless curiosity, shared by the deep sea and the sky. With every gaze, one's field of vision expands."
   },
   {
     "name": "琥珀",
     "reading": "こはく",
     "english": "amber",
     "weight": 0.4,
-    "flavor": "樹液が時間を閉じ込めた、記憶の興味を宿す粒子。古代の生命を内側に封じる。"
+    "flavor": "樹液が時間を閉じ込めた、記憶の興味を宿す粒子。古代の生命を内側に封じる。",
+    "flavor_en": "A particle of remembering curiosity, where sap has sealed time within. Ancient lives are preserved inside its glow."
   },
   {
     "name": "珊瑚",
     "reading": "さんご",
     "english": "coral",
     "weight": 0.5,
-    "flavor": "海中の宝石としてゆっくり育つ、生きた興味の粒子。生命と装飾の境界に咲く。"
+    "flavor": "海中の宝石としてゆっくり育つ、生きた興味の粒子。生命と装飾の境界に咲く。",
+    "flavor_en": "A living particle of curiosity, slowly grown as the jewel of the sea. It blossoms on the border of life and adornment."
   },
   {
     "name": "薄紅",
     "reading": "うすべに",
     "english": "light pink",
     "weight": 0.8,
-    "flavor": "頬を染める最初の温度を持つ、初々しい興味の粒子。心の鼓動を写し取る色。"
+    "flavor": "頬を染める最初の温度を持つ、初々しい興味の粒子。心の鼓動を写し取る色。",
+    "flavor_en": "A fresh particle of curiosity bearing the first warmth that tints the cheek. A hue that transcribes the pulse of the heart."
   },
   {
     "name": "深緑",
     "reading": "ふかみどり",
     "english": "deep green",
     "weight": 0.9,
-    "flavor": "原生林の奥に潜む、重厚な興味の粒子。時間の蓄積が緑をここまで暗くしていく。"
+    "flavor": "原生林の奥に潜む、重厚な興味の粒子。時間の蓄積が緑をここまで暗くしていく。",
+    "flavor_en": "A weighty particle of curiosity lurking in the depths of primeval forest. Only the accumulation of time can darken green this far."
   },
   {
     "name": "群青",
     "reading": "ぐんじょう",
     "english": "ultramarine",
     "weight": 0.7,
-    "flavor": "祈りと夜空を結ぶ、神聖な興味の粒子。曼荼羅にも空にも宿る至高の青。"
+    "flavor": "祈りと夜空を結ぶ、神聖な興味の粒子。曼荼羅にも空にも宿る至高の青。",
+    "flavor_en": "A sacred particle of curiosity binding prayer and the night sky. The supreme blue that dwells in both mandala and heavens."
   },
   {
     "name": "牡丹色",
     "reading": "ぼたんいろ",
     "english": "peony color",
     "weight": 0.6,
-    "flavor": "華やかさを極めた紅、豪奢な興味の粒子。和服の主役にふさわしい王の色。"
+    "flavor": "華やかさを極めた紅、豪奢な興味の粒子。和服の主役にふさわしい王の色。",
+    "flavor_en": "An opulent particle of curiosity, a crimson at the summit of splendor. A regal hue worthy of being the centerpiece of kimono."
   }
 ]

--- a/data/nouns/concepts.json
+++ b/data/nouns/concepts.json
@@ -4,139 +4,159 @@
     "reading": "ゆめ",
     "english": "dream",
     "weight": 1.0,
-    "flavor": "眠りの中で組み立てられる、もう一つの興味の粒子。覚めても余韻が一日を彩る。"
+    "flavor": "眠りの中で組み立てられる、もう一つの興味の粒子。覚めても余韻が一日を彩る。",
+    "flavor_en": "A particle of curiosity assembled within sleep; its afterglow tints the day even after waking."
   },
   {
     "name": "光",
     "reading": "ひかり",
     "english": "light",
     "weight": 1.0,
-    "flavor": "速度の限界に立つ、純粋な興味の粒子。届くこと自体が小さな奇跡を運んでいる。"
+    "flavor": "速度の限界に立つ、純粋な興味の粒子。届くこと自体が小さな奇跡を運んでいる。",
+    "flavor_en": "A pure particle of curiosity standing at the edge of velocity; its mere arrival carries a quiet miracle."
   },
   {
     "name": "影",
     "reading": "かげ",
     "english": "shadow",
     "weight": 1.0,
-    "flavor": "光があるから生まれる、対の興味を宿す粒子。輪郭をなぞって本体を浮き彫りにする。"
+    "flavor": "光があるから生まれる、対の興味を宿す粒子。輪郭をなぞって本体を浮き彫りにする。",
+    "flavor_en": "A particle housing the counter-curiosity born only because light exists; it traces outlines and reveals the body beneath."
   },
   {
     "name": "風",
     "reading": "かぜ",
     "english": "wind",
     "weight": 1.0,
-    "flavor": "形を持たぬまま全てを撫でる、自由な興味の粒子。吹けば思考の塵まで運んでいく。"
+    "flavor": "形を持たぬまま全てを撫でる、自由な興味の粒子。吹けば思考の塵まで運んでいく。",
+    "flavor_en": "A free particle of curiosity that caresses all things while holding no shape; when it blows, it carries away even the dust of thought."
   },
   {
     "name": "雲",
     "reading": "くも",
     "english": "cloud",
     "weight": 1.0,
-    "flavor": "空に浮かぶ即興の彫刻、移ろいの興味を宿す粒子。同じ形は一秒として続かない。"
+    "flavor": "空に浮かぶ即興の彫刻、移ろいの興味を宿す粒子。同じ形は一秒として続かない。",
+    "flavor_en": "An improvised sculpture floating in the sky, a particle housing the curiosity of transience; no shape persists for even a single second."
   },
   {
     "name": "雨",
     "reading": "あめ",
     "english": "rain",
     "weight": 1.0,
-    "flavor": "天が地を撫でる時の手触り、慰めの興味を宿す粒子。落ちる音だけで世界が静まる。"
+    "flavor": "天が地を撫でる時の手触り、慰めの興味を宿す粒子。落ちる音だけで世界が静まる。",
+    "flavor_en": "The texture of the heavens stroking the earth, a particle housing the curiosity of consolation; the world quiets at the mere sound of its descent."
   },
   {
     "name": "雪",
     "reading": "ゆき",
     "english": "snow",
     "weight": 1.0,
-    "flavor": "六角形の沈黙が降り積もる、静寂の興味の粒子。音を吸い込んで世界を初期化する。"
+    "flavor": "六角形の沈黙が降り積もる、静寂の興味の粒子。音を吸い込んで世界を初期化する。",
+    "flavor_en": "A particle of silent curiosity in which hexagonal hush accumulates; it absorbs sound and resets the world."
   },
   {
     "name": "霧",
     "reading": "きり",
     "english": "fog",
     "weight": 1.0,
-    "flavor": "視界を奪うことで観察を促す、逆説の興味を宿す粒子。輪郭の不在こそが想像を生む。"
+    "flavor": "視界を奪うことで観察を促す、逆説の興味を宿す粒子。輪郭の不在こそが想像を生む。",
+    "flavor_en": "A paradoxical particle of curiosity that invites observation by stealing sight; the absence of outline is precisely what gives birth to imagination."
   },
   {
     "name": "虹",
     "reading": "にじ",
     "english": "rainbow",
     "weight": 0.7,
-    "flavor": "雨と光の和解の証、希望の興味を宿す粒子。橋として現れては静かに消えていく。"
+    "flavor": "雨と光の和解の証、希望の興味を宿す粒子。橋として現れては静かに消えていく。",
+    "flavor_en": "A witness to the reconciliation of rain and light, a particle housing the curiosity of hope; it appears as a bridge and quietly fades."
   },
   {
     "name": "星",
     "reading": "ほし",
     "english": "star",
     "weight": 1.0,
-    "flavor": "遥か昔の光が今届く、時差を抱えた興味の粒子。見える星のいくつかは既に失われている。"
+    "flavor": "遥か昔の光が今届く、時差を抱えた興味の粒子。見える星のいくつかは既に失われている。",
+    "flavor_en": "A particle of curiosity bearing a temporal lag, where ancient light arrives only now; several of the stars we see have already been lost."
   },
   {
     "name": "月",
     "reading": "つき",
     "english": "moon",
     "weight": 1.0,
-    "flavor": "夜の鏡となって地球を見守る、静謐な興味の粒子。満ち欠けで心の周期を導いてくる。"
+    "flavor": "夜の鏡となって地球を見守る、静謐な興味の粒子。満ち欠けで心の周期を導いてくる。",
+    "flavor_en": "A serene particle of curiosity that becomes the mirror of night and watches over the earth; its waxing and waning guide the cycles of the heart."
   },
   {
     "name": "太陽",
     "reading": "たいよう",
     "english": "sun",
     "weight": 1.0,
-    "flavor": "全ての始まりを灯す、原初の興味の粒子。直視できないほどの恩恵を毎朝届ける。"
+    "flavor": "全ての始まりを灯す、原初の興味の粒子。直視できないほどの恩恵を毎朝届ける。",
+    "flavor_en": "A primordial particle of curiosity that ignites every beginning; each morning it delivers a grace too great to gaze upon."
   },
   {
     "name": "空",
     "reading": "そら",
     "english": "sky",
     "weight": 1.0,
-    "flavor": "無限の容れ物として広がる、開放の興味の粒子。何もないからこそ全てを許容する。"
+    "flavor": "無限の容れ物として広がる、開放の興味の粒子。何もないからこそ全てを許容する。",
+    "flavor_en": "A particle of open curiosity spreading as an infinite vessel; precisely because it holds nothing, it permits everything."
   },
   {
     "name": "海",
     "reading": "うみ",
     "english": "sea",
     "weight": 1.0,
-    "flavor": "塩と命の揺り籠として広がる、深淵の興味の粒子。表面の波の下には別の宇宙がある。"
+    "flavor": "塩と命の揺り籠として広がる、深淵の興味の粒子。表面の波の下には別の宇宙がある。",
+    "flavor_en": "A particle of abyssal curiosity spreading as a cradle of salt and life; beneath its surface waves lies another universe."
   },
   {
     "name": "山",
     "reading": "やま",
     "english": "mountain",
     "weight": 1.0,
-    "flavor": "大地が天を目指した形、不動の興味を宿す粒子。仰ぐ者の心を一段引き上げてくれる。"
+    "flavor": "大地が天を目指した形、不動の興味を宿す粒子。仰ぐ者の心を一段引き上げてくれる。",
+    "flavor_en": "The form of the earth aspiring toward the heavens, a particle housing immovable curiosity; it raises by one degree the heart of whoever looks up."
   },
   {
     "name": "川",
     "reading": "かわ",
     "english": "river",
     "weight": 1.0,
-    "flavor": "終わりなく流れ続ける、変化の興味を宿す粒子。同じ水に二度と入れぬのが理となる。"
+    "flavor": "終わりなく流れ続ける、変化の興味を宿す粒子。同じ水に二度と入れぬのが理となる。",
+    "flavor_en": "A particle housing the curiosity of change that flows on without end; it is the law that one cannot step into the same water twice."
   },
   {
     "name": "森",
     "reading": "もり",
     "english": "forest",
     "weight": 1.0,
-    "flavor": "無数の生命が呼吸する、多声の興味を宿す粒子。一歩ごとに時間の進み方が変わる。"
+    "flavor": "無数の生命が呼吸する、多声の興味を宿す粒子。一歩ごとに時間の進み方が変わる。",
+    "flavor_en": "A polyphonic particle of curiosity where countless lives breathe in unison; with every step, the pace of time itself shifts."
   },
   {
     "name": "道",
     "reading": "みち",
     "english": "road",
     "weight": 1.0,
-    "flavor": "歩く者によって生まれる、可能性の興味の粒子。引き返す自由も含めて道と呼ぶ。"
+    "flavor": "歩く者によって生まれる、可能性の興味の粒子。引き返す自由も含めて道と呼ぶ。",
+    "flavor_en": "A particle of possible curiosity born of those who walk it; the freedom to turn back is also counted as part of the road."
   },
   {
     "name": "橋",
     "reading": "はし",
     "english": "bridge",
     "weight": 1.0,
-    "flavor": "断絶を縫い直す、和解の興味を宿す粒子。架ける覚悟を持つ者だけが渡れる軌跡。"
+    "flavor": "断絶を縫い直す、和解の興味を宿す粒子。架ける覚悟を持つ者だけが渡れる軌跡。",
+    "flavor_en": "A particle housing the curiosity of reconciliation that re-stitches what has been severed; a trajectory only those resolved to build it may cross."
   },
   {
     "name": "門",
     "reading": "もん",
     "english": "gate",
     "weight": 0.9,
-    "flavor": "外と内を区切る、選択の興味を宿す粒子。くぐる前と後で世界の解像度が変わる。"
+    "flavor": "外と内を区切る、選択の興味を宿す粒子。くぐる前と後で世界の解像度が変わる。",
+    "flavor_en": "A particle housing the curiosity of choice that separates outside from in; the resolution of the world differs before and after one passes through."
   }
 ]

--- a/data/nouns/elements.json
+++ b/data/nouns/elements.json
@@ -4,139 +4,159 @@
     "reading": "ひ",
     "english": "fire",
     "weight": 1.0,
-    "flavor": "全てを変質させる、最古の興味の粒子。あたためる手にもなり奪う爪にもなる。"
+    "flavor": "全てを変質させる、最古の興味の粒子。あたためる手にもなり奪う爪にもなる。",
+    "flavor_en": "The most ancient particle of curiosity, transmuting all it touches; it becomes the warming hand and the seizing claw alike."
   },
   {
     "name": "水",
     "reading": "みず",
     "english": "water",
     "weight": 1.0,
-    "flavor": "形を持たぬことで形を選び続ける、柔軟な興味の粒子。命と腐敗の両方を運ぶ。"
+    "flavor": "形を持たぬことで形を選び続ける、柔軟な興味の粒子。命と腐敗の両方を運ぶ。",
+    "flavor_en": "A pliant particle of curiosity that, by holding no form, perpetually chooses its form; it carries both life and decay."
   },
   {
     "name": "土",
     "reading": "つち",
     "english": "earth",
     "weight": 1.0,
-    "flavor": "始まりと終わりを受け取る、母性の興味を宿す粒子。踏みしめれば思考が落ち着く。"
+    "flavor": "始まりと終わりを受け取る、母性の興味を宿す粒子。踏みしめれば思考が落ち着く。",
+    "flavor_en": "A particle housing maternal curiosity that receives every beginning and ending; press your foot upon it and thought finds its center."
   },
   {
     "name": "風",
     "reading": "かぜ",
     "english": "wind",
     "weight": 1.0,
-    "flavor": "見えぬまま世界を巡る、伝令の興味を宿す粒子。記憶も匂いも全て運んでくれる。"
+    "flavor": "見えぬまま世界を巡る、伝令の興味を宿す粒子。記憶も匂いも全て運んでくれる。",
+    "flavor_en": "A particle housing the curiosity of the messenger that circuits the world unseen; it carries memory and scent and all things between."
   },
   {
     "name": "雷",
     "reading": "かみなり",
     "english": "thunder",
     "weight": 0.8,
-    "flavor": "天から伸びる白い舌、神聖と恐怖の興味を宿す粒子。瞬間に世界を真実で割る。"
+    "flavor": "天から伸びる白い舌、神聖と恐怖の興味を宿す粒子。瞬間に世界を真実で割る。",
+    "flavor_en": "A white tongue extending from the heavens, a particle housing the curiosity of the sacred and the fearful; in an instant it cleaves the world with truth."
   },
   {
     "name": "氷",
     "reading": "こおり",
     "english": "ice",
     "weight": 1.0,
-    "flavor": "時間を凍らせる結晶、保存の興味を宿す粒子。冷たさの内側に静かな秩序を蔵す。"
+    "flavor": "時間を凍らせる結晶、保存の興味を宿す粒子。冷たさの内側に静かな秩序を蔵す。",
+    "flavor_en": "A crystal that freezes time, a particle housing the curiosity of preservation; within its coldness it harbours a silent order."
   },
   {
     "name": "闇",
     "reading": "やみ",
     "english": "darkness",
     "weight": 0.6,
-    "flavor": "光が描けぬ世界を抱える、母性の興味の粒子。見えないからこそ可能性が無限大。"
+    "flavor": "光が描けぬ世界を抱える、母性の興味の粒子。見えないからこそ可能性が無限大。",
+    "flavor_en": "A maternal particle of curiosity that embraces the world light cannot draw; precisely because nothing is seen, possibility becomes infinite."
   },
   {
     "name": "聖",
     "reading": "せい",
     "english": "holy",
     "weight": 0.4,
-    "flavor": "穢れを濾過する透き通った興味の粒子。触れた瞬間に空間の周波数が整っていく。"
+    "flavor": "穢れを濾過する透き通った興味の粒子。触れた瞬間に空間の周波数が整っていく。",
+    "flavor_en": "A translucent particle of curiosity that filters away defilement; the moment it is touched, the frequency of the space itself begins to align."
   },
   {
     "name": "毒",
     "reading": "どく",
     "english": "poison",
     "weight": 0.7,
-    "flavor": "命を脅かすことで命の輪郭を引き、警告の興味を宿す粒子。薄めれば薬にも転じる。"
+    "flavor": "命を脅かすことで命の輪郭を引き、警告の興味を宿す粒子。薄めれば薬にも転じる。",
+    "flavor_en": "A particle housing the curiosity of warning that draws the outline of life by threatening it; diluted, it turns into medicine."
   },
   {
     "name": "鉄",
     "reading": "てつ",
     "english": "iron",
     "weight": 1.0,
-    "flavor": "硬さと重さで文明を支えた、骨格の興味を宿す粒子。錆びてなお歴史の証人となる。"
+    "flavor": "硬さと重さで文明を支えた、骨格の興味を宿す粒子。錆びてなお歴史の証人となる。",
+    "flavor_en": "A particle housing the curiosity of the skeleton, which supported civilization through hardness and weight; even rusted, it remains a witness to history."
   },
   {
     "name": "銅",
     "reading": "どう",
     "english": "copper",
     "weight": 1.0,
-    "flavor": "緑青に化ける優しさを持つ、時を含む興味の粒子。十年経つほど深みを増していく。"
+    "flavor": "緑青に化ける優しさを持つ、時を含む興味の粒子。十年経つほど深みを増していく。",
+    "flavor_en": "A particle of time-laden curiosity, gentle enough to transmute into verdigris; with each passing decade, its depth only deepens."
   },
   {
     "name": "銀",
     "reading": "ぎん",
     "english": "silver",
     "weight": 0.6,
-    "flavor": "月光を結晶化した、清廉な興味の粒子。汚れを写すことで持ち主の運を測る。"
+    "flavor": "月光を結晶化した、清廉な興味の粒子。汚れを写すことで持ち主の運を測る。",
+    "flavor_en": "A pure-hearted particle of curiosity, the crystallization of moonlight; by reflecting impurity, it gauges the fortune of its bearer."
   },
   {
     "name": "金",
     "reading": "きん",
     "english": "gold",
     "weight": 0.3,
-    "flavor": "永遠を象徴する、不変の興味を宿す粒子。元素の中で最も詩人に愛された輝き。"
+    "flavor": "永遠を象徴する、不変の興味を宿す粒子。元素の中で最も詩人に愛された輝き。",
+    "flavor_en": "A particle housing immutable curiosity, the very symbol of eternity; among all elements, the radiance most beloved by poets."
   },
   {
     "name": "鉛",
     "reading": "なまり",
     "english": "lead",
     "weight": 0.9,
-    "flavor": "重く沈み込む、忍耐の興味を宿す粒子。錬金術師が金を夢見た出発点でもある。"
+    "flavor": "重く沈み込む、忍耐の興味を宿す粒子。錬金術師が金を夢見た出発点でもある。",
+    "flavor_en": "A heavy, sinking particle housing the curiosity of endurance; it is also the starting point from which alchemists dreamed of gold."
   },
   {
     "name": "錫",
     "reading": "すず",
     "english": "tin",
     "weight": 0.8,
-    "flavor": "柔らかく錆びにくい、控えめな興味の粒子。器となり酒を清らかに保ってきた。"
+    "flavor": "柔らかく錆びにくい、控えめな興味の粒子。器となり酒を清らかに保ってきた。",
+    "flavor_en": "A modest particle of curiosity, soft yet slow to rust; becoming a vessel, it has long kept wine pure."
   },
   {
     "name": "水銀",
     "reading": "すいぎん",
     "english": "mercury",
     "weight": 0.5,
-    "flavor": "液体である金属、矛盾の興味を宿す粒子。掴めぬ流動性が世界の常識を揺らす。"
+    "flavor": "液体である金属、矛盾の興味を宿す粒子。掴めぬ流動性が世界の常識を揺らす。",
+    "flavor_en": "A metal that is liquid, a particle housing the curiosity of contradiction; its ungraspable fluidity unsettles the common sense of the world."
   },
   {
     "name": "硫黄",
     "reading": "いおう",
     "english": "sulfur",
     "weight": 0.7,
-    "flavor": "黄色く煙る、変容の興味を宿す粒子。香りそのものが警告と魔術を同時に運ぶ。"
+    "flavor": "黄色く煙る、変容の興味を宿す粒子。香りそのものが警告と魔術を同時に運ぶ。",
+    "flavor_en": "A yellow-smoking particle housing the curiosity of transmutation; its very scent carries warning and sorcery in a single breath."
   },
   {
     "name": "炭",
     "reading": "すみ",
     "english": "charcoal",
     "weight": 1.0,
-    "flavor": "燃えた残りこそ価値となる、再生の興味の粒子。黒の中に未来の熱が休んでいる。"
+    "flavor": "燃えた残りこそ価値となる、再生の興味の粒子。黒の中に未来の熱が休んでいる。",
+    "flavor_en": "A particle of regenerative curiosity in which what remains after burning becomes the true value; within its blackness, the heat of a future rests."
   },
   {
     "name": "塩",
     "reading": "しお",
     "english": "salt",
     "weight": 1.0,
-    "flavor": "結晶化した海、保存と清めの興味を宿す粒子。命の味を境界線として刻みつける。"
+    "flavor": "結晶化した海、保存と清めの興味を宿す粒子。命の味を境界線として刻みつける。",
+    "flavor_en": "A crystallized sea, a particle housing the curiosity of preservation and purification; it engraves the taste of life as a boundary line."
   },
   {
     "name": "砂",
     "reading": "すな",
     "english": "sand",
     "weight": 1.0,
-    "flavor": "石が時間に磨かれた終着点、無常の興味の粒子。一粒に世界の縮図が眠っている。"
+    "flavor": "石が時間に磨かれた終着点、無常の興味の粒子。一粒に世界の縮図が眠っている。",
+    "flavor_en": "The terminus where stone has been polished by time, a particle of the curiosity of impermanence; within a single grain sleeps a miniature of the world."
   }
 ]

--- a/data/nouns/foods.json
+++ b/data/nouns/foods.json
@@ -4,139 +4,159 @@
     "reading": "こめ",
     "english": "rice",
     "weight": 1.0,
-    "flavor": "日々を支える、勤勉な興味の粒子。一粒に八十八の手間が宿ると伝えられてきた。"
+    "flavor": "日々を支える、勤勉な興味の粒子。一粒に八十八の手間が宿ると伝えられてきた。",
+    "flavor_en": "A diligent particle of curiosity that sustains each passing day. It is said that eighty-eight labors dwell within a single grain."
   },
   {
     "name": "麦",
     "reading": "むぎ",
     "english": "wheat",
     "weight": 1.0,
-    "flavor": "風になびく金色の海、豊穣の興味を宿す粒子。挽かれてなお誰かの朝を温める。"
+    "flavor": "風になびく金色の海、豊穣の興味を宿す粒子。挽かれてなお誰かの朝を温める。",
+    "flavor_en": "A golden sea swaying in the wind, a particle harboring the interest of abundance. Even when ground to flour, it warms someone's morning."
   },
   {
     "name": "豆",
     "reading": "まめ",
     "english": "bean",
     "weight": 1.0,
-    "flavor": "小さな殻に未来を畳み込む、可能性の興味の粒子。発芽の力は哲学を超えてくる。"
+    "flavor": "小さな殻に未来を畳み込む、可能性の興味の粒子。発芽の力は哲学を超えてくる。",
+    "flavor_en": "A particle of possibility, folding the future into a small shell. The power of germination surpasses philosophy itself."
   },
   {
     "name": "芋",
     "reading": "いも",
     "english": "potato",
     "weight": 1.0,
-    "flavor": "土の中で静かに肥える、辛抱強い興味の粒子。地味な見た目に膨大な熱量を秘める。"
+    "flavor": "土の中で静かに肥える、辛抱強い興味の粒子。地味な見た目に膨大な熱量を秘める。",
+    "flavor_en": "A patient particle of curiosity, quietly fattening within the soil. Beneath its plain appearance hides immense caloric warmth."
   },
   {
     "name": "魚",
     "reading": "さかな",
     "english": "fish",
     "weight": 1.0,
-    "flavor": "海から食卓へ運ばれる、栄養の興味を宿す粒子。命を頂く儀礼を最も身近に教える。"
+    "flavor": "海から食卓へ運ばれる、栄養の興味を宿す粒子。命を頂く儀礼を最も身近に教える。",
+    "flavor_en": "A particle of nourishment carried from sea to table. It teaches the rite of receiving life in the most intimate manner."
   },
   {
     "name": "肉",
     "reading": "にく",
     "english": "meat",
     "weight": 1.0,
-    "flavor": "他の命を取り込むことで生まれる、強さの興味の粒子。歓喜と罪悪を同時に抱く食。"
+    "flavor": "他の命を取り込むことで生まれる、強さの興味の粒子。歓喜と罪悪を同時に抱く食。",
+    "flavor_en": "A particle of strength born from absorbing another's life. A food that holds joy and guilt in the very same bite."
   },
   {
     "name": "卵",
     "reading": "たまご",
     "english": "egg",
     "weight": 1.0,
-    "flavor": "全ての可能性が殻に閉じる、始まりの興味の粒子。割られて初めて未来が選ばれる。"
+    "flavor": "全ての可能性が殻に閉じる、始まりの興味の粒子。割られて初めて未来が選ばれる。",
+    "flavor_en": "A particle of beginnings, where all possibilities are sealed within a shell. Only once broken is a single future chosen."
   },
   {
     "name": "乳",
     "reading": "ちち",
     "english": "milk",
     "weight": 1.0,
-    "flavor": "母なる命が分け与える、慈愛の興味を宿す粒子。栄養と温度を併せて運んでくる。"
+    "flavor": "母なる命が分け与える、慈愛の興味を宿す粒子。栄養と温度を併せて運んでくる。",
+    "flavor_en": "A particle of compassion, shared by the maternal source of life. It carries both nourishment and warmth in a single draught."
   },
   {
     "name": "果",
     "reading": "み",
     "english": "fruit",
     "weight": 1.0,
-    "flavor": "甘さで誘い種を運ばせる、戦略の興味を宿す粒子。色と香りで世界を交渉する。"
+    "flavor": "甘さで誘い種を運ばせる、戦略の興味を宿す粒子。色と香りで世界を交渉する。",
+    "flavor_en": "A strategic particle that lures with sweetness so its seeds may travel. It negotiates with the world through color and fragrance."
   },
   {
     "name": "菜",
     "reading": "な",
     "english": "vegetable",
     "weight": 1.0,
-    "flavor": "緑のまま命をくれる、清涼な興味の粒子。日々の身体を整える静かな主役。"
+    "flavor": "緑のまま命をくれる、清涼な興味の粒子。日々の身体を整える静かな主役。",
+    "flavor_en": "A cool, clear particle that grants life while still green. The quiet protagonist that orders the body day by day."
   },
   {
     "name": "茸",
     "reading": "きのこ",
     "english": "mushroom",
     "weight": 1.0,
-    "flavor": "光なき森で繁る、神秘の興味を宿す粒子。生と死の境界をやさしく和らげていく。"
+    "flavor": "光なき森で繁る、神秘の興味を宿す粒子。生と死の境界をやさしく和らげていく。",
+    "flavor_en": "A particle of mystery that flourishes in lightless forests. It gently softens the boundary between life and death."
   },
   {
     "name": "海苔",
     "reading": "のり",
     "english": "seaweed",
     "weight": 1.0,
-    "flavor": "黒い紙のように波を畳み込んだ、海の興味の粒子。香りに磯の記憶を封じている。"
+    "flavor": "黒い紙のように波を畳み込んだ、海の興味の粒子。香りに磯の記憶を封じている。",
+    "flavor_en": "A particle of the sea, with waves folded like black paper. Its fragrance seals away the memory of the rocky shore."
   },
   {
     "name": "昆布",
     "reading": "こんぶ",
     "english": "kelp",
     "weight": 0.9,
-    "flavor": "海中で揺れて旨味を育てる、忍耐の興味を宿す粒子。出汁となり料理の根を支える。"
+    "flavor": "海中で揺れて旨味を育てる、忍耐の興味を宿す粒子。出汁となり料理の根を支える。",
+    "flavor_en": "A patient particle that sways underwater, cultivating umami in silence. As broth, it supports the very root of cuisine."
   },
   {
     "name": "鰹",
     "reading": "かつお",
     "english": "bonito",
     "weight": 0.8,
-    "flavor": "海を疾走し続ける、力強い興味の粒子。削られて初めて深い甘さを放つ命の象徴。"
+    "flavor": "海を疾走し続ける、力強い興味の粒子。削られて初めて深い甘さを放つ命の象徴。",
+    "flavor_en": "A powerful particle that races forever through the sea. A symbol of life whose deep sweetness emerges only once shaved away."
   },
   {
     "name": "味噌",
     "reading": "みそ",
     "english": "miso",
     "weight": 1.0,
-    "flavor": "豆と時間と菌が織りなす、熟成の興味の粒子。一杯の汁で家郷の輪郭が立ち上がる。"
+    "flavor": "豆と時間と菌が織りなす、熟成の興味の粒子。一杯の汁で家郷の輪郭が立ち上がる。",
+    "flavor_en": "A particle of maturation woven from beans, time, and microbes. A single bowl of soup conjures the outline of home."
   },
   {
     "name": "醤油",
     "reading": "しょうゆ",
     "english": "soy sauce",
     "weight": 1.0,
-    "flavor": "黒く薫る液体、調和の興味を宿す粒子。一滴で皿の世界を引き締めてくれる。"
+    "flavor": "黒く薫る液体、調和の興味を宿す粒子。一滴で皿の世界を引き締めてくれる。",
+    "flavor_en": "A dark, fragrant liquid, a particle harboring the interest of harmony. A single drop tightens the entire world of the plate."
   },
   {
     "name": "酒",
     "reading": "さけ",
     "english": "sake",
     "weight": 1.0,
-    "flavor": "穀物が時間を経て香る、酩酊の興味を宿す粒子。喜びを増幅し悲しみを薄めてくれる。"
+    "flavor": "穀物が時間を経て香る、酩酊の興味を宿す粒子。喜びを増幅し悲しみを薄めてくれる。",
+    "flavor_en": "A particle of intoxication, where grain grows fragrant through time. It amplifies joy and dilutes sorrow in equal measure."
   },
   {
     "name": "茶",
     "reading": "ちゃ",
     "english": "tea",
     "weight": 1.0,
-    "flavor": "葉から立ち上る静かな興味の粒子。一服のうちに時間の流れがゆっくりと変わる。"
+    "flavor": "葉から立ち上る静かな興味の粒子。一服のうちに時間の流れがゆっくりと変わる。",
+    "flavor_en": "A quiet particle of curiosity rising from the leaf. Within a single sip, the flow of time slowly transforms."
   },
   {
     "name": "塩",
     "reading": "しお",
     "english": "salt",
     "weight": 1.0,
-    "flavor": "海から取り出した命の輪郭、清めの興味を宿す粒子。味を引き出す静かな鍵となる。"
+    "flavor": "海から取り出した命の輪郭、清めの興味を宿す粒子。味を引き出す静かな鍵となる。",
+    "flavor_en": "An outline of life drawn from the sea, a particle of purification. It becomes the silent key that draws forth all flavor."
   },
   {
     "name": "砂糖",
     "reading": "さとう",
     "english": "sugar",
     "weight": 1.0,
-    "flavor": "甘さを結晶化した、誘惑の興味を宿す粒子。少量で気分を翻し過ぎれば毒となる。"
+    "flavor": "甘さを結晶化した、誘惑の興味を宿す粒子。少量で気分を翻し過ぎれば毒となる。",
+    "flavor_en": "A particle of temptation, the crystallization of sweetness itself. A trace turns the mood; an excess becomes poison."
   }
 ]

--- a/data/nouns/objects.json
+++ b/data/nouns/objects.json
@@ -4,139 +4,159 @@
     "reading": "ほん",
     "english": "book",
     "weight": 1.0,
-    "flavor": "閉じた表紙に世界を畳み込む、知識の興味を宿す粒子。開けば時空が立ち上がる。"
+    "flavor": "閉じた表紙に世界を畳み込む、知識の興味を宿す粒子。開けば時空が立ち上がる。",
+    "flavor_en": "A particle of knowledge, folding the world inside a closed cover. To open it is to raise time and space anew."
   },
   {
     "name": "剣",
     "reading": "けん",
     "english": "sword",
     "weight": 0.7,
-    "flavor": "意志を鋼に変えた、決断の興味を宿す粒子。刃は持ち主の覚悟と等しく研がれる。"
+    "flavor": "意志を鋼に変えた、決断の興味を宿す粒子。刃は持ち主の覚悟と等しく研がれる。",
+    "flavor_en": "A particle of resolve, where will has been forged into steel. The blade is sharpened to the measure of its bearer's resolve."
   },
   {
     "name": "鏡",
     "reading": "かがみ",
     "english": "mirror",
     "weight": 1.0,
-    "flavor": "見られる側を見つめ返す、再帰の興味を宿す粒子。真実は表面ではなく裏にある。"
+    "flavor": "見られる側を見つめ返す、再帰の興味を宿す粒子。真実は表面ではなく裏にある。",
+    "flavor_en": "A recursive particle that gazes back at the gazer. The truth resides not on its surface but behind it."
   },
   {
     "name": "鍵",
     "reading": "かぎ",
     "english": "key",
     "weight": 1.0,
-    "flavor": "閉ざされた可能性を開く、選択の興味を宿す粒子。形は答えそのものを写している。"
+    "flavor": "閉ざされた可能性を開く、選択の興味を宿す粒子。形は答えそのものを写している。",
+    "flavor_en": "A particle of choice that opens sealed possibilities. Its very shape is the silhouette of the answer."
   },
   {
     "name": "時計",
     "reading": "とけい",
     "english": "clock",
     "weight": 1.0,
-    "flavor": "時間を刻むことで時間を縛る、矛盾した興味を宿す粒子。針が世界の鼓動を測る。"
+    "flavor": "時間を刻むことで時間を縛る、矛盾した興味を宿す粒子。針が世界の鼓動を測る。",
+    "flavor_en": "A paradoxical particle that binds time by carving it. Its hands measure the heartbeat of the world."
   },
   {
     "name": "灯",
     "reading": "ひ",
     "english": "lamp",
     "weight": 1.0,
-    "flavor": "暗闇に小さな秩序を灯す、希望の興味を宿す粒子。揺らぎながら確かに導いてくる。"
+    "flavor": "暗闇に小さな秩序を灯す、希望の興味を宿す粒子。揺らぎながら確かに導いてくる。",
+    "flavor_en": "A particle of hope, kindling a small order within the dark. Trembling, yet it guides with unwavering certainty."
   },
   {
     "name": "杯",
     "reading": "さかずき",
     "english": "cup",
     "weight": 1.0,
-    "flavor": "満たされることを待つ、受容の興味を宿す粒子。器であることそのものが祈りとなる。"
+    "flavor": "満たされることを待つ、受容の興味を宿す粒子。器であることそのものが祈りとなる。",
+    "flavor_en": "A particle of acceptance, awaiting the moment of being filled. To be a vessel is itself an act of prayer."
   },
   {
     "name": "箱",
     "reading": "はこ",
     "english": "box",
     "weight": 1.0,
-    "flavor": "中身を秘めることで価値を生む、期待の興味を宿す粒子。開ける前が一番眩しい。"
+    "flavor": "中身を秘めることで価値を生む、期待の興味を宿す粒子。開ける前が一番眩しい。",
+    "flavor_en": "A particle of anticipation whose worth lies in concealment. The moment before opening shines brightest of all."
   },
   {
     "name": "扇",
     "reading": "おうぎ",
     "english": "fan",
     "weight": 0.9,
-    "flavor": "風を従えて舞う、所作の興味を宿す粒子。閉じた姿に物語をすべて畳み込む。"
+    "flavor": "風を従えて舞う、所作の興味を宿す粒子。閉じた姿に物語をすべて畳み込む。",
+    "flavor_en": "A particle of gesture, dancing while commanding the wind. Within its folded form, every story is contained."
   },
   {
     "name": "琴",
     "reading": "こと",
     "english": "koto",
     "weight": 0.6,
-    "flavor": "弦が空気を震わせる、調和の興味を宿す粒子。指先が触れて初めて魂を露わにする。"
+    "flavor": "弦が空気を震わせる、調和の興味を宿す粒子。指先が触れて初めて魂を露わにする。",
+    "flavor_en": "A particle of harmony, its strings trembling the very air. Only at the touch of fingertips does its soul reveal itself."
   },
   {
     "name": "笛",
     "reading": "ふえ",
     "english": "flute",
     "weight": 0.8,
-    "flavor": "息を音に変換する、変質の興味を宿す粒子。誰のものでもない響きが世界を貫く。"
+    "flavor": "息を音に変換する、変質の興味を宿す粒子。誰のものでもない響きが世界を貫く。",
+    "flavor_en": "A particle of transformation, converting breath into tone. A resonance belonging to no one pierces clean through the world."
   },
   {
     "name": "太鼓",
     "reading": "たいこ",
     "english": "drum",
     "weight": 0.9,
-    "flavor": "皮の張力で大地を叩く、原始の興味を宿す粒子。心音の遠い親戚として鳴り続ける。"
+    "flavor": "皮の張力で大地を叩く、原始の興味を宿す粒子。心音の遠い親戚として鳴り続ける。",
+    "flavor_en": "A primal particle that strikes the earth through stretched hide. It sounds on as a distant kin of the heartbeat."
   },
   {
     "name": "筆",
     "reading": "ふで",
     "english": "brush",
     "weight": 1.0,
-    "flavor": "墨と紙の間を取り持つ、表現の興味を宿す粒子。線一本に書き手の呼吸が宿る。"
+    "flavor": "墨と紙の間を取り持つ、表現の興味を宿す粒子。線一本に書き手の呼吸が宿る。",
+    "flavor_en": "A particle of expression, mediating between ink and paper. Within a single line dwells the breath of the one who drew it."
   },
   {
     "name": "硯",
     "reading": "すずり",
     "english": "inkstone",
     "weight": 0.7,
-    "flavor": "墨をじっくり育てる、思索の興味を宿す粒子。摩擦と水で言葉を整える静かな器。"
+    "flavor": "墨をじっくり育てる、思索の興味を宿す粒子。摩擦と水で言葉を整える静かな器。",
+    "flavor_en": "A contemplative particle that cultivates ink with patience. A quiet vessel that orders words through friction and water."
   },
   {
     "name": "玉",
     "reading": "たま",
     "english": "jewel",
     "weight": 0.5,
-    "flavor": "球体に光を閉じ込めた、完全性の興味を宿す粒子。手のひらで世界の縮図を回す。"
+    "flavor": "球体に光を閉じ込めた、完全性の興味を宿す粒子。手のひらで世界の縮図を回す。",
+    "flavor_en": "A particle of perfection, sealing light within a sphere. Upon the palm, a miniature world is set in motion."
   },
   {
     "name": "環",
     "reading": "わ",
     "english": "ring",
     "weight": 0.8,
-    "flavor": "終わりと始まりを結び直す、循環の興味を宿す粒子。閉じることで永遠を約束する。"
+    "flavor": "終わりと始まりを結び直す、循環の興味を宿す粒子。閉じることで永遠を約束する。",
+    "flavor_en": "A particle of circulation, joining end to beginning anew. By closing itself, it promises an unbroken eternity."
   },
   {
     "name": "冠",
     "reading": "かんむり",
     "english": "crown",
     "weight": 0.3,
-    "flavor": "頭上に責任を載せる、権威の興味を宿す粒子。輝きより重さこそが王の真実となる。"
+    "flavor": "頭上に責任を載せる、権威の興味を宿す粒子。輝きより重さこそが王の真実となる。",
+    "flavor_en": "A particle of authority, settling responsibility upon the head. Not its luster but its weight is the true measure of a king."
   },
   {
     "name": "袋",
     "reading": "ふくろ",
     "english": "bag",
     "weight": 1.0,
-    "flavor": "中を見せずに運ぶ、可能性の興味を宿す粒子。膨らみの形が想像力を試してくる。"
+    "flavor": "中を見せずに運ぶ、可能性の興味を宿す粒子。膨らみの形が想像力を試してくる。",
+    "flavor_en": "A particle of possibility, carrying contents unseen. The shape of its swelling puts the imagination to the test."
   },
   {
     "name": "糸",
     "reading": "いと",
     "english": "thread",
     "weight": 1.0,
-    "flavor": "見えにくいほど世界を繋ぐ、結縁の興味を宿す粒子。撚れば布、断てば自由となる。"
+    "flavor": "見えにくいほど世界を繋ぐ、結縁の興味を宿す粒子。撚れば布、断てば自由となる。",
+    "flavor_en": "A particle of binding affinity, joining the world the more invisibly it runs. Twisted, it becomes cloth; severed, it becomes freedom."
   },
   {
     "name": "針",
     "reading": "はり",
     "english": "needle",
     "weight": 1.0,
-    "flavor": "極小の鋭さで運命を縫う、精密さの興味を宿す粒子。穴を通すたびに物語が結ばれる。"
+    "flavor": "極小の鋭さで運命を縫う、精密さの興味を宿す粒子。穴を通すたびに物語が結ばれる。",
+    "flavor_en": "A particle of precision, sewing fate with a minuscule edge. Each passage through the eye binds another story together."
   }
 ]

--- a/data/nouns/phenomena.json
+++ b/data/nouns/phenomena.json
@@ -4,139 +4,159 @@
     "reading": "あさ",
     "english": "morning",
     "weight": 1.0,
-    "flavor": "世界が再起動する瞬間に立ち昇る、希望の興味の粒子。最初の光が全てを書き直す。"
+    "flavor": "世界が再起動する瞬間に立ち昇る、希望の興味の粒子。最初の光が全てを書き直す。",
+    "flavor_en": "A particle of hope rising at the very instant the world reboots. The first light rewrites everything from the start."
   },
   {
     "name": "昼",
     "reading": "ひる",
     "english": "noon",
     "weight": 1.0,
-    "flavor": "陰影が短くなる、活動の興味を宿す粒子。世界が最も明瞭に観測できる時間帯。"
+    "flavor": "陰影が短くなる、活動の興味を宿す粒子。世界が最も明瞭に観測できる時間帯。",
+    "flavor_en": "A particle of activity where every shadow grows short. The hour at which the world may be observed at its clearest."
   },
   {
     "name": "夕",
     "reading": "ゆう",
     "english": "evening",
     "weight": 1.0,
-    "flavor": "境界を金色に染める、郷愁の興味を宿す粒子。一日の終わりにだけ宿る独特の質感。"
+    "flavor": "境界を金色に染める、郷愁の興味を宿す粒子。一日の終わりにだけ宿る独特の質感。",
+    "flavor_en": "A particle of nostalgia, dyeing every boundary in gold. A texture that dwells only at the closing of the day."
   },
   {
     "name": "夜",
     "reading": "よる",
     "english": "night",
     "weight": 1.0,
-    "flavor": "活動の音が静まり想念が立ち上がる、内省の興味の粒子。眠りと夢の入り口となる。"
+    "flavor": "活動の音が静まり想念が立ち上がる、内省の興味の粒子。眠りと夢の入り口となる。",
+    "flavor_en": "A particle of introspection, where the noise of action quiets and thought begins to rise. It becomes the threshold of sleep and dream."
   },
   {
     "name": "春",
     "reading": "はる",
     "english": "spring",
     "weight": 1.0,
-    "flavor": "凍えていた可能性が芽吹く、再生の興味の粒子。気温と一緒に心も解凍されていく。"
+    "flavor": "凍えていた可能性が芽吹く、再生の興味の粒子。気温と一緒に心も解凍されていく。",
+    "flavor_en": "A particle of renewal where frozen possibilities sprout anew. As temperature rises, the heart too begins to thaw."
   },
   {
     "name": "夏",
     "reading": "なつ",
     "english": "summer",
     "weight": 1.0,
-    "flavor": "命が最大出力で謳歌する、爆発の興味の粒子。汗と影と入道雲が記憶を濃く焼く。"
+    "flavor": "命が最大出力で謳歌する、爆発の興味の粒子。汗と影と入道雲が記憶を濃く焼く。",
+    "flavor_en": "A particle of detonation where life sings at maximum output. Sweat, shadow, and thunderhead burn memory deep."
   },
   {
     "name": "秋",
     "reading": "あき",
     "english": "autumn",
     "weight": 1.0,
-    "flavor": "豊穣と離別が同居する、内省の興味を宿す粒子。葉の色が時間の経過を可視化する。"
+    "flavor": "豊穣と離別が同居する、内省の興味を宿す粒子。葉の色が時間の経過を可視化する。",
+    "flavor_en": "A particle of introspection where harvest and parting share a single house. The color of leaves makes the passage of time visible."
   },
   {
     "name": "冬",
     "reading": "ふゆ",
     "english": "winter",
     "weight": 1.0,
-    "flavor": "全てが内側へ向かう、静寂の興味を宿す粒子。眠ることでしか進めぬ深さがある。"
+    "flavor": "全てが内側へ向かう、静寂の興味を宿す粒子。眠ることでしか進めぬ深さがある。",
+    "flavor_en": "A particle of stillness, turning all things inward. There exists a depth one can reach only by sleeping."
   },
   {
     "name": "嵐",
     "reading": "あらし",
     "english": "storm",
     "weight": 0.7,
-    "flavor": "天が暴れる、解放の興味を宿す粒子。秩序を一度壊して新たな秩序を呼び寄せる。"
+    "flavor": "天が暴れる、解放の興味を宿す粒子。秩序を一度壊して新たな秩序を呼び寄せる。",
+    "flavor_en": "A particle of release, the heavens cast into fury. Order is shattered once so that a new order may be summoned."
   },
   {
     "name": "凪",
     "reading": "なぎ",
     "english": "calm",
     "weight": 0.8,
-    "flavor": "風も波も止まる、緊張の興味を宿す粒子。完全な静けさは何かの予感に似ている。"
+    "flavor": "風も波も止まる、緊張の興味を宿す粒子。完全な静けさは何かの予感に似ている。",
+    "flavor_en": "A particle of tension where wind and wave both cease. A perfect stillness resembles the omen of something yet to come."
   },
   {
     "name": "潮",
     "reading": "しお",
     "english": "tide",
     "weight": 0.9,
-    "flavor": "月の引力で海が呼吸する、周期の興味を宿す粒子。満ちては引く律動が命を運ぶ。"
+    "flavor": "月の引力で海が呼吸する、周期の興味を宿す粒子。満ちては引く律動が命を運ぶ。",
+    "flavor_en": "A particle of cycle where the sea breathes by the pull of the moon. The rhythm of filling and withdrawing ferries life along."
   },
   {
     "name": "波",
     "reading": "なみ",
     "english": "wave",
     "weight": 1.0,
-    "flavor": "繰り返しでありながら同じものは一つもない、揺らぎの興味の粒子。岸を磨き続ける。"
+    "flavor": "繰り返しでありながら同じものは一つもない、揺らぎの興味の粒子。岸を磨き続ける。",
+    "flavor_en": "A particle of fluctuation, repeating endlessly yet never the same twice. It polishes the shore without rest."
   },
   {
     "name": "渦",
     "reading": "うず",
     "english": "whirlpool",
     "weight": 0.6,
-    "flavor": "中心へ引き寄せる、求心の興味を宿す粒子。流れの中の特異点として記憶される。"
+    "flavor": "中心へ引き寄せる、求心の興味を宿す粒子。流れの中の特異点として記憶される。",
+    "flavor_en": "A centripetal particle that draws all things toward its center. It is remembered as a singularity within the flow."
   },
   {
     "name": "煙",
     "reading": "けむり",
     "english": "smoke",
     "weight": 1.0,
-    "flavor": "燃え尽きた後にだけ立ち昇る、痕跡の興味の粒子。消えながら何かを伝え続ける。"
+    "flavor": "燃え尽きた後にだけ立ち昇る、痕跡の興味の粒子。消えながら何かを伝え続ける。",
+    "flavor_en": "A particle of trace, rising only after the fire has spent itself. Even as it vanishes, it continues to convey something."
   },
   {
     "name": "炎",
     "reading": "ほのお",
     "english": "flame",
     "weight": 0.8,
-    "flavor": "形を持たぬまま踊る、変質の興味を宿す粒子。同じ色を二度と再現できない芸術。"
+    "flavor": "形を持たぬまま踊る、変質の興味を宿す粒子。同じ色を二度と再現できない芸術。",
+    "flavor_en": "A particle of transformation, dancing without form of its own. An art whose color can never be reproduced twice."
   },
   {
     "name": "露",
     "reading": "つゆ",
     "english": "dew",
     "weight": 1.0,
-    "flavor": "葉先に世界を一滴で映す、儚さの興味の粒子。朝日が昇るまでの限定芸術となる。"
+    "flavor": "葉先に世界を一滴で映す、儚さの興味の粒子。朝日が昇るまでの限定芸術となる。",
+    "flavor_en": "A particle of transience, reflecting the entire world in a single drop at the leaf's tip. A limited art that lasts only until sunrise."
   },
   {
     "name": "霜",
     "reading": "しも",
     "english": "frost",
     "weight": 0.9,
-    "flavor": "夜の冷気が地表に描く、結晶の興味を宿す粒子。歩けば崩れる繊細な美の建築。"
+    "flavor": "夜の冷気が地表に描く、結晶の興味を宿す粒子。歩けば崩れる繊細な美の建築。",
+    "flavor_en": "A particle of crystallization, sketched upon the ground by the cold of night. A delicate architecture of beauty that crumbles at a step."
   },
   {
     "name": "雹",
     "reading": "ひょう",
     "english": "hail",
     "weight": 0.5,
-    "flavor": "天から降る氷の弾丸、衝撃の興味を宿す粒子。空が固体を放つという驚きの現象。"
+    "flavor": "天から降る氷の弾丸、衝撃の興味を宿す粒子。空が固体を放つという驚きの現象。",
+    "flavor_en": "A particle of impact, bullets of ice cast down from the heavens. The astonishing phenomenon of the sky releasing solid matter."
   },
   {
     "name": "雷鳴",
     "reading": "らいめい",
     "english": "thunder",
     "weight": 0.6,
-    "flavor": "光の後に遅れて届く、轟きの興味を宿す粒子。距離を音速で測らせる古い時計。"
+    "flavor": "光の後に遅れて届く、轟きの興味を宿す粒子。距離を音速で測らせる古い時計。",
+    "flavor_en": "A particle of roar, arriving belatedly after the flash. An ancient clock that lets one measure distance by the speed of sound."
   },
   {
     "name": "地震",
     "reading": "じしん",
     "english": "earthquake",
     "weight": 0.4,
-    "flavor": "大地が震えて存在の前提を揺さぶる、根源の興味の粒子。立っている事実を問い直す。"
+    "flavor": "大地が震えて存在の前提を揺さぶる、根源の興味の粒子。立っている事実を問い直す。",
+    "flavor_en": "A primal particle, the earth trembling and shaking the premise of existence itself. It interrogates the very fact of standing upright."
   }
 ]

--- a/data/nouns/plants.json
+++ b/data/nouns/plants.json
@@ -4,174 +4,199 @@
     "reading": "さくら",
     "english": "cherry blossom",
     "weight": 1.0,
-    "flavor": "短い満開に全てを賭ける、儚さの興味を司る粒子。散り際こそ最大の表現となる。"
+    "flavor": "短い満開に全てを賭ける、儚さの興味を司る粒子。散り際こそ最大の表現となる。",
+    "flavor_en": "A particle presiding over the curiosity of transience, wagering all on a brief full bloom. The moment of falling is its greatest expression."
   },
   {
     "name": "薔薇",
     "reading": "ばら",
     "english": "rose",
     "weight": 1.0,
-    "flavor": "棘とともに咲く、誇りと愛欲の興味を宿した粒子。色ごとに異なる感情を語る。"
+    "flavor": "棘とともに咲く、誇りと愛欲の興味を宿した粒子。色ごとに異なる感情を語る。",
+    "flavor_en": "A particle harboring the curiosity of pride and desire, blooming with thorns. Each hue tells a different emotion."
   },
   {
     "name": "蓮",
     "reading": "はす",
     "english": "lotus",
     "weight": 0.7,
-    "flavor": "泥から立ち上がり清浄を保つ、悟りの興味を宿す粒子。水面の上で目覚めを誓う。"
+    "flavor": "泥から立ち上がり清浄を保つ、悟りの興味を宿す粒子。水面の上で目覚めを誓う。",
+    "flavor_en": "A particle of awakening curiosity, rising from the mire yet keeping its purity. It vows to awaken upon the surface of the water."
   },
   {
     "name": "竹",
     "reading": "たけ",
     "english": "bamboo",
     "weight": 1.0,
-    "flavor": "節を重ねてしなやかに伸びる、忍耐の興味の粒子。中空の心は折れずに歌う。"
+    "flavor": "節を重ねてしなやかに伸びる、忍耐の興味の粒子。中空の心は折れずに歌う。",
+    "flavor_en": "A particle of patient curiosity, stretching supple through stacked nodes. Its hollow heart bends but never breaks, and sings."
   },
   {
     "name": "松",
     "reading": "まつ",
     "english": "pine",
     "weight": 1.0,
-    "flavor": "千年を超えて変わらぬ、不変の興味を象徴する粒子。緑の常を雪にも貫き通す。"
+    "flavor": "千年を超えて変わらぬ、不変の興味を象徴する粒子。緑の常を雪にも貫き通す。",
+    "flavor_en": "A particle symbolizing the curiosity of immutability, unchanged across a thousand years. It carries its constant green even through snow."
   },
   {
     "name": "梅",
     "reading": "うめ",
     "english": "plum blossom",
     "weight": 1.0,
-    "flavor": "雪の中に先駆けて咲く、勇気の興味を宿す粒子。寒さに香り立つ最初の春。"
+    "flavor": "雪の中に先駆けて咲く、勇気の興味を宿す粒子。寒さに香り立つ最初の春。",
+    "flavor_en": "A particle of courageous curiosity, blooming foremost amid the snow. The first spring whose fragrance rises against the cold."
   },
   {
     "name": "菊",
     "reading": "きく",
     "english": "chrysanthemum",
     "weight": 1.0,
-    "flavor": "重なる花弁に皇統を宿す、清廉な興味の粒子。秋の終わりにこそ威厳を放つ。"
+    "flavor": "重なる花弁に皇統を宿す、清廉な興味の粒子。秋の終わりにこそ威厳を放つ。",
+    "flavor_en": "A particle of pure curiosity, harboring imperial lineage in its layered petals. Its dignity shines brightest at autumn's end."
   },
   {
     "name": "蘭",
     "reading": "らん",
     "english": "orchid",
     "weight": 0.8,
-    "flavor": "深山にひっそりと咲く、洗練された興味の粒子。気高さは目立たぬ場所で磨かれる。"
+    "flavor": "深山にひっそりと咲く、洗練された興味の粒子。気高さは目立たぬ場所で磨かれる。",
+    "flavor_en": "A refined particle of curiosity, blooming quietly deep in the mountains. Nobility is honed in places unseen."
   },
   {
     "name": "藤",
     "reading": "ふじ",
     "english": "wisteria",
     "weight": 0.9,
-    "flavor": "垂れ下がる紫房に時を編み込む、優美な興味の粒子。風が来れば波のように揺らぐ。"
+    "flavor": "垂れ下がる紫房に時を編み込む、優美な興味の粒子。風が来れば波のように揺らぐ。",
+    "flavor_en": "An elegant particle of curiosity, weaving time into its drooping violet clusters. At the wind's arrival, it sways like a wave."
   },
   {
     "name": "椿",
     "reading": "つばき",
     "english": "camellia",
     "weight": 0.9,
-    "flavor": "厳冬に首ごと落ちる、潔さの興味を宿す粒子。緋の輝きで雪の静けさを破る。"
+    "flavor": "厳冬に首ごと落ちる、潔さの興味を宿す粒子。緋の輝きで雪の静けさを破る。",
+    "flavor_en": "A particle of resolute curiosity, falling head and all in the deep of winter. Its scarlet brilliance breaks the silence of the snow."
   },
   {
     "name": "楓",
     "reading": "かえで",
     "english": "maple",
     "weight": 1.0,
-    "flavor": "秋にだけ赤く燃え上がる、変容の興味を司る粒子。落葉は別れの儀式となる。"
+    "flavor": "秋にだけ赤く燃え上がる、変容の興味を司る粒子。落葉は別れの儀式となる。",
+    "flavor_en": "A particle presiding over the curiosity of transformation, burning red only in autumn. The falling leaf becomes a rite of parting."
   },
   {
     "name": "柳",
     "reading": "やなぎ",
     "english": "willow",
     "weight": 1.0,
-    "flavor": "風に逆らわず流れる、しなやかな興味の粒子。垂れ下がる枝に水辺の物語を綴る。"
+    "flavor": "風に逆らわず流れる、しなやかな興味の粒子。垂れ下がる枝に水辺の物語を綴る。",
+    "flavor_en": "A supple particle of curiosity, flowing without resistance to the wind. Its drooping branches inscribe the tales of the waterside."
   },
   {
     "name": "檜",
     "reading": "ひのき",
     "english": "cypress",
     "weight": 0.8,
-    "flavor": "千年の社を支え続けた、清浄な興味の粒子。木目に祈りの記憶を刻んでいる。"
+    "flavor": "千年の社を支え続けた、清浄な興味の粒子。木目に祈りの記憶を刻んでいる。",
+    "flavor_en": "A pure particle of curiosity that has upheld shrines for a thousand years. The memory of prayer is carved into its grain."
   },
   {
     "name": "杉",
     "reading": "すぎ",
     "english": "cedar",
     "weight": 1.0,
-    "flavor": "天を目指して直立する、誠実な興味の粒子。森の柱としてまっすぐ立ち続ける。"
+    "flavor": "天を目指して直立する、誠実な興味の粒子。森の柱としてまっすぐ立ち続ける。",
+    "flavor_en": "An honest particle of curiosity, standing upright toward the heavens. As the pillar of the forest, it goes on standing straight."
   },
   {
     "name": "蔦",
     "reading": "つた",
     "english": "ivy",
     "weight": 1.0,
-    "flavor": "壁を緑で包み込む、執着と帰属の興味を宿す粒子。時を経るほど絡みが強くなる。"
+    "flavor": "壁を緑で包み込む、執着と帰属の興味を宿す粒子。時を経るほど絡みが強くなる。",
+    "flavor_en": "A particle harboring the curiosity of attachment and belonging, swathing walls in green. The longer time passes, the tighter its grasp."
   },
   {
     "name": "葦",
     "reading": "あし",
     "english": "reed",
     "weight": 1.0,
-    "flavor": "水辺で群れる、しなやかで詩的な興味の粒子。一本一本が世界の囁きを増幅する。"
+    "flavor": "水辺で群れる、しなやかで詩的な興味の粒子。一本一本が世界の囁きを増幅する。",
+    "flavor_en": "A supple, poetic particle of curiosity, gathering at the waterside. Each single stalk amplifies the whispering of the world."
   },
   {
     "name": "芒",
     "reading": "すすき",
     "english": "pampas grass",
     "weight": 1.0,
-    "flavor": "風になびく銀の穂を持つ、無常の興味を宿す粒子。月夜の野原に光の波を生む。"
+    "flavor": "風になびく銀の穂を持つ、無常の興味を宿す粒子。月夜の野原に光の波を生む。",
+    "flavor_en": "A particle of impermanent curiosity, bearing silver plumes that sway in the wind. In moonlit fields it births waves of light."
   },
   {
     "name": "菫",
     "reading": "すみれ",
     "english": "violet",
     "weight": 0.9,
-    "flavor": "石垣の隙間に咲く、控えめな興味の粒子。小さくとも紫の誇りは確かにある。"
+    "flavor": "石垣の隙間に咲く、控えめな興味の粒子。小さくとも紫の誇りは確かにある。",
+    "flavor_en": "A modest particle of curiosity, blooming in the cracks of stone walls. Small though it is, its violet pride is unmistakable."
   },
   {
     "name": "桔梗",
     "reading": "ききょう",
     "english": "bellflower",
     "weight": 0.8,
-    "flavor": "五角の星形を秘めた、清らかな興味の粒子。雨の前にだけ蕾を結ぶ予言者。"
+    "flavor": "五角の星形を秘めた、清らかな興味の粒子。雨の前にだけ蕾を結ぶ予言者。",
+    "flavor_en": "A pure particle of curiosity, concealing a five-pointed star within. A prophet that closes its buds only before the rain."
   },
   {
     "name": "牡丹",
     "reading": "ぼたん",
     "english": "peony",
     "weight": 0.7,
-    "flavor": "百花の王と呼ばれる、豪奢な興味の粒子。一輪で庭の主役を担う気品を持つ。"
+    "flavor": "百花の王と呼ばれる、豪奢な興味の粒子。一輪で庭の主役を担う気品を持つ。",
+    "flavor_en": "An opulent particle of curiosity, hailed as the king of a hundred flowers. A single bloom holds the grace to lead the garden."
   },
   {
     "name": "百合",
     "reading": "ゆり",
     "english": "lily",
     "weight": 0.9,
-    "flavor": "純白の鐘形に祈りを湛えた、聖なる興味の粒子。香りで空間を浄化していく。"
+    "flavor": "純白の鐘形に祈りを湛えた、聖なる興味の粒子。香りで空間を浄化していく。",
+    "flavor_en": "A sacred particle of curiosity, brimming with prayer in its pure white bell. Its fragrance gradually purifies the surrounding space."
   },
   {
     "name": "紫陽花",
     "reading": "あじさい",
     "english": "hydrangea",
     "weight": 1.0,
-    "flavor": "土と空の対話で色を変える、移ろいの興味を宿す粒子。雨こそ最大の友となる。"
+    "flavor": "土と空の対話で色を変える、移ろいの興味を宿す粒子。雨こそ最大の友となる。",
+    "flavor_en": "A particle of shifting curiosity, changing hue through the dialogue of soil and sky. The rain itself becomes its greatest companion."
   },
   {
     "name": "向日葵",
     "reading": "ひまわり",
     "english": "sunflower",
     "weight": 1.0,
-    "flavor": "太陽を追って首を巡らす、明朗な興味の粒子。種の螺旋に宇宙の比率を蔵す。"
+    "flavor": "太陽を追って首を巡らす、明朗な興味の粒子。種の螺旋に宇宙の比率を蔵す。",
+    "flavor_en": "A radiant particle of curiosity, turning its head to follow the sun. The spiral of its seeds holds the proportions of the cosmos."
   },
   {
     "name": "朝顔",
     "reading": "あさがお",
     "english": "morning glory",
     "weight": 1.0,
-    "flavor": "夏の朝にだけ咲く、勤勉な興味の粒子。蔓を伸ばす方向に未来を読み取る。"
+    "flavor": "夏の朝にだけ咲く、勤勉な興味の粒子。蔓を伸ばす方向に未来を読み取る。",
+    "flavor_en": "A diligent particle of curiosity, blooming only in the summer mornings. One reads the future in the direction its vines extend."
   },
   {
     "name": "彼岸花",
     "reading": "ひがんばな",
     "english": "red spider lily",
     "weight": 0.6,
-    "flavor": "彼岸の頃に突如咲く、境界の興味を宿す粒子。緋の群生は別世界の合図となる。"
+    "flavor": "彼岸の頃に突如咲く、境界の興味を宿す粒子。緋の群生は別世界の合図となる。",
+    "flavor_en": "A particle of liminal curiosity, blooming abruptly around the equinox. Its scarlet colonies become a signal from another world."
   }
 ]


### PR DESCRIPTION
## 関連 Issue

closes #65 (i18n Phase 2 — flavor 268 件英訳)
Parent: #63 (i18n umbrella)、Phase 1 は #66 でマージ済み (9c97178)

## 変更内容

\`data/nouns/*.json\` の **全 268 件** に \`flavor_en\` フィールドを追加。コード変更ゼロ、データ追加のみ。

| ファイル | 件数 |
|---|---|
| abstracts.json | 52 |
| animals.json | 66 |
| colors.json | 25 |
| concepts.json | 20 |
| elements.json | 20 |
| foods.json | 20 |
| objects.json | 20 |
| phenomena.json | 20 |
| plants.json | 25 |
| **合計** | **268** |

## 翻訳の世界観

- 「興味の粒子」「興味」→ \`particle of curiosity\` / \`interest\`
- 「観測者」「観測」→ \`observer\` / \`observation\`
- 「結晶化」「結晶」→ \`crystallization\` / \`crystal\`
- 「軌道」→ \`orbit\` / \`trajectory\`
- 文学的・やや格調高い英語（口語ではない）
- カテゴリ別トーン: abstracts は最も哲学的、phenomena は最も詩的、objects/foods は象徴的かつ地に足のついた表現

## 翻訳サンプル

| noun | EN flavor |
|---|---|
| 犬 (dog) | A particle that crystallizes faithful interest. Resonating with its master's heart even from afar. |
| 創造 (creation) | A spark-like particle of interest, raising being from nonbeing. The radiance of the moment that transforms the observer into the maker. |
| 渦 (whirlpool) | A centripetal particle that draws all things toward its center. It is remembered as a singularity within the flow. |
| 霜 (frost) | A particle of crystallization, sketched upon the ground by the cold of night. A delicate architecture of beauty that crumbles at a step. |

## 実装手法

5 並列サブエージェントでカテゴリ分担:
- A: animals (66)
- B: abstracts (52)
- C: colors + plants (50)
- D: concepts + elements (40)
- E: foods + objects + phenomena (60)

全エージェントに共通スタイルガイド (世界観語彙 + 格調高い英語) を渡し、既存の犬・猫・魚・愛などの JA flavor を翻訳サンプルとして参照させた。

## 形式

- 既存 \`flavor\` (JA) は完全に無変更
- フィールド順序を全 268 件で \`name, reading, english, weight, flavor, flavor_en\` に統一
- indent 2 / 末尾改行 / JSON 構造維持

## テスト

- \`cargo test\`: **244 passed**（Phase 1 と同じ件数、コード変更なしのため増減なし）
- \`cargo clippy --all-targets -- -D warnings\`: clean
- 全 9 ファイルで `flavor_en` 抜けゼロ確認済み

## 次のステップ（別 Issue 想定）

Phase 1 (#66) のコードは flavor を JA 固定で表示している。本 PR マージ後、別 PR で:
- \`Curion::flavor_for(lang)\` 風のヘルパーを追加して英モード時に flavor_en を返す
- ui.rs の flavor 描画箇所を lang 経由に切替
- flavor の表示テストを追加