### PR TITLE
docs: kako-jun/curion#65 followup — CHANGELOG / roadmap / spec for Phase 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - i18n foundation (#63 Phase 1): English is now the canonical UI locale with a runtime switch to Japanese via a new Settings tab. `←/→` toggles the language and persists it immediately. Tab names, sections, block titles, help-line labels, and category names are routed through a static `t(key, lang)` translation table. `Language { En, Ja }` (default `En`) lives on `SerializableGameState` with `#[serde(default)]` so older save files load as English. Flavor / achievement / synthesis-message English translations are tracked separately under #65.
+- i18n flavor data (#65 Phase 2): every one of the 268 nouns now carries a `flavor_en` field alongside the existing Japanese `flavor`. Translations preserve the curion world vocabulary ("particle of curiosity", "observer", "crystallization") with a per-category tone (abstracts most philosophical, phenomena most poetic, objects/foods symbolic but grounded). No code change yet — flavor display routing through the language gate is tracked under #68 (Phase 3).
 
 ## v0.2.0 - 2026-05-17
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -119,7 +119,9 @@
 
 3. **文化交流機能**
    - 漢字トレード推奨システム
-   - 多言語対応（進行中: Phase 1 完了 / Issue #63）
+   - 多言語対応（進行中: Phase 1/2 完了 / Issue #63）
      - Phase 1 完了: i18n 基盤 + Settings タブの En/Ja 切替 + 主要 UI ラベルの翻訳
-     - Phase 2 未完了: flavor / 実績 / デイリーミッション説明文の英訳（Issue #65）
+     - Phase 2 完了: 268 nouns 全件に `flavor_en` データ追加（Issue #65）
+     - Phase 3 未完了: flavor の lang gate 表示切替 + interest/curiosity 表記統一（Issue #68）
+     - Phase 4 候補: 実績タイトル / デイリーミッション説明文 / Evolution display_name / 合成失敗メッセージ の英訳（未起票）
    - グローバルランキング

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -34,7 +34,18 @@ Each curion has:
 | Phenomena | ~20 | Thunder, Rainbow |
 | Abstracts | 52 | Love, Freedom, Chaos |
 
-Noun data is stored in `data/nouns/*.json` (one file per category).
+Noun data is stored in `data/nouns/*.json` (one file per category). Each entry has the following fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | The Japanese name. Also used as the internal noun ID (see `Curion::noun`, `match_curion`, `AchievementType::SpecificNoun`). |
+| `reading` | yes | Hiragana / katakana reading of `name`. |
+| `english` | yes | Canonical English label. Surfaced through `App::display_curion_name` when the language is `En`. |
+| `weight` | yes | Relative spawn weight inside the category. |
+| `flavor` | yes | Japanese flavor text (SF / philosophical short prose). |
+| `flavor_en` | yes (since #65 Phase 2) | English flavor text. Phase 3 (Issue #68) will route flavor rendering through the language gate; until then the UI always displays `flavor`. |
+
+Synthesis-only nouns generated at runtime (e.g. `蒸気`, `残骸`) may not have an entry in this database, in which case English lookups fall back to the JA noun.
 
 ## Latent Vector Pipeline (Issue #39)
 


### PR DESCRIPTION
## 背景

PR #67 (i18n Phase 2 flavor_en データ追加) は「コード変更ゼロ、データのみ」のスコープで進めた結果、CHANGELOG / roadmap / spec の更新を含めずにマージしてしまった (kako-jun が漏れを指摘)。本 PR は docs のみのフォローアップ。

## 変更内容

- **CHANGELOG.md** Unreleased: Phase 1 エントリの隣に Phase 2 (flavor_en 268 件) のエントリを追加、Phase 3 (#68) フォローアップに言及
- **docs/roadmap.md** 多言語対応セクション: 「Phase 1 完了 / Phase 2 未完了」→「Phase 1/2 完了 / Phase 3 (#68) 未完了 / Phase 4 (未起票)」に更新
- **docs/spec.md** Noun data セクション: `data/nouns/*.json` の各フィールド (name / reading / english / weight / flavor / **flavor_en**) のスキーマ表を新規追加 + synthesis-only noun fallback の明記

## スコープ
- コード変更ゼロ
- `cargo test`: 244 passed (変動なし)
- `cargo clippy --all-targets -- -D warnings`: clean

## 関連
- 親 Issue: #63 (i18n umbrella)
- 完了済 PR: #66 (Phase 1) / #67 (Phase 2 データ)
- 次の Issue: #68 (Phase 3 flavor lang gate + 表記統一)