### PR TITLE
release: v0.3.0 — event-driven save + i18n Phase 1/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,23 @@
 
 ## Unreleased
 
+## v0.3.0 - 2026-05-22
+
+The "event-driven + bilingual" release: save is no longer a 60-second poll, and the UI can switch between English (default) and Japanese at runtime.
+
 ### Added
-- i18n foundation (#63 Phase 1): English is now the canonical UI locale with a runtime switch to Japanese via a new Settings tab. `←/→` toggles the language and persists it immediately. Tab names, sections, block titles, help-line labels, and category names are routed through a static `t(key, lang)` translation table. `Language { En, Ja }` (default `En`) lives on `SerializableGameState` with `#[serde(default)]` so older save files load as English. Flavor / achievement / synthesis-message English translations are tracked separately under #65.
-- i18n flavor data (#65 Phase 2): every one of the 268 nouns now carries a `flavor_en` field alongside the existing Japanese `flavor`. Translations preserve the curion world vocabulary ("particle of curiosity", "observer", "crystallization") with a per-category tone (abstracts most philosophical, phenomena most poetic, objects/foods symbolic but grounded). No code change yet — flavor display routing through the language gate is tracked under #68 (Phase 3).
+- i18n foundation (#63 Phase 1): English is now the canonical UI locale with a runtime switch to Japanese via a new Settings tab. `←/→` toggles the language and persists it immediately. Tab names, sections, block titles, help-line labels, and category names are routed through a static `t(key, lang)` translation table. `Language { En, Ja }` (default `En`) lives on `SerializableGameState` with `#[serde(default)]` so older save files load as English.
+- i18n flavor data (#65 Phase 2): every one of the 268 nouns now carries a `flavor_en` field alongside the existing Japanese `flavor`. Translations preserve the curion world vocabulary ("particle of curiosity", "observer", "crystallization") with a per-category tone (abstracts most philosophical, phenomena most poetic, objects/foods symbolic but grounded). Flavor display routing through the language gate is tracked under #68 (Phase 3).
+- Settings tab (6th tab): currently houses the language switch; future settings (theme, profile reset, public key display) will land here.
+
+### Changed
+- Event-driven save (#62): the 60-second auto-save poll and the manual `s` save key are gone. Persistence is now driven by an `App::dirty` flag set at the six mutation points (gacha pull, equip toggle, achievement claim, synthesis success / risky-failure, daily mission auto-claim). The main loop flushes to disk right after a key event or `on_tick` whenever `dirty` is true. Continuous values (`play_time`, SAN decay, rare cooldown) deliberately do not arm `dirty` — they are covered by startup / shutdown saves. `s` outside filter mode is now a no-op so `/`-filter typing of "s" works correctly.
+- `Curion` rendering goes through `App::display_curion_name(&Curion)`, which formats as `"{Category} の {noun}"` in Ja, `"{english} ({Category})"` in En with a runtime `NounDatabase::english_for` lookup, and falls back to `"{ja-noun} ({Category-En})"` when the English entry is missing (synthesis-only nouns).
+
+### Internal
+- `Tab::COUNT` constant + propagation through `from_index` / `next` / `section_indices` / `handle_key` so adding a tab is a single-knob change.
+- All-new `src/i18n.rs` (OnceLock-backed `t(key, lang)` table) with a debug-only `#[should_panic]` test that catches unregistered keys at the call site (release builds return `"?"`).
+- 244 tests pass (203 baseline + 11 dirty-flag + 30 i18n coverage). `cargo clippy --all-targets -- -D warnings` clean.
 
 ## v0.2.0 - 2026-05-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "curion"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cargo-husky",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curion"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["kako-jun"]
 description = "A SF collection game where you gather particles of curiosity"


### PR DESCRIPTION
## v0.3.0 リリース準備

v0.2.0 以降に main へ入った下記の変更をまとめて公開する。

### 含まれる変更

| Commit | 内容 |
|---|---|
| 9c97178 | #62 event-driven save (PR #64) |
| eb0d51a | #63 Phase 1 i18n 基盤 (PR #66) |
| 2297283 | #65 Phase 2 flavor_en 268 件 (PR #67) |
| deeccbb | docs フォロー (PR #69) |

### バージョン

- \`Cargo.toml\`: \`0.2.0\` → \`0.3.0\`
- \`CHANGELOG.md\`: \`Unreleased\` を \`v0.3.0 - 2026-05-22\` に切り出し

### テスト

- \`cargo build\`: OK
- \`cargo test\`: **244 passed** (v0.2.0 比 +47)
- \`cargo clippy --all-targets -- -D warnings\`: clean
- \`cargo fmt --check\`: clean

### マージ後

1. \`git tag v0.3.0\`
2. \`git push --tags\`
3. \`gh release create v0.3.0 --notes-from-tag\`
4. \`cargo publish\`

### セーブ互換

- 旧セーブ (\`language\` フィールド無し) は \`Language::En\` でロード (\`#[serde(default)]\`)
- \`Curion::noun\` (JA) は内部 ID として無変更、英語表示は runtime ルックアップ + JA fallback