### PR TITLE
fix: kako-jun/curion#73 interactive モードから save コマンドを完全削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Removed
+- Interactive モードの `save` コマンドを削除 (#73, #62 follow-up)。永続化は startup / exit / tui / Ctrl-D の自動セーブに一本化。
+
 ## v0.3.0 - 2026-05-22
 
 The "event-driven + bilingual" release: save is no longer a 60-second poll, and the UI can switch between English (default) and Japanese at runtime.

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -27,7 +27,6 @@ const COMMANDS: &[&str] = &[
     "achievements",
     "ach",
     "stats",
-    "save",
     "tui",
     "help",
     "?",
@@ -298,15 +297,6 @@ pub fn run_interactive_mode(profile_manager: &ProfileManager) -> Result<()> {
                     }
                     "stats" => {
                         cmd_stats(&game_state, session_start.elapsed().as_secs());
-                    }
-                    "save" => {
-                        game_state
-                            .player
-                            .add_play_time(session_start.elapsed().as_secs());
-                        match save_manager.save(&game_state) {
-                            Ok(()) => println!("Game saved."),
-                            Err(e) => eprintln!("Save failed: {e:?}"),
-                        }
                     }
                     "tui" => {
                         // プレイ時間を加算してセーブ
@@ -666,7 +656,6 @@ fn show_help() {
     println!("  \x1b[1;33mcollection\x1b[0m (col)         Show your collection");
     println!("  \x1b[1;33machievements\x1b[0m (ach)       Show achievements");
     println!("  \x1b[1;33mstats\x1b[0m                    Show statistics");
-    println!("  \x1b[1;33msave\x1b[0m                     Manual save");
     println!("  \x1b[1;33mtui\x1b[0m                      Switch to TUI mode");
     println!("  \x1b[1;33mhelp\x1b[0m, \x1b[1;33m?\x1b[0m                 Show this help");
     println!("  \x1b[1;33mexit\x1b[0m, \x1b[1;33mquit\x1b[0m              Exit the game");


### PR DESCRIPTION
## 関連 Issue
closes #73

## 背景

#62 で event-driven save に切り替えて「手動 Save メニュー削除」と謳ったが、interactive モードのコマンドメニューに `save` が残っていた、という follow-up。

## 変更内容

`src/interactive.rs` から save コマンド関連 3 箇所を削除（純粋な削除、11 行）:

1. `COMMANDS` 配列から `"save"` を除外
2. `match cmd` の `"save" => { ... save_manager.save(...) ... }` ハンドラブロック (8 行)
3. `show_help()` から `save                     Manual save` の行

## 動作確認

- `cargo build`: OK
- `cargo test`: 244 passed; 0 failed
- `cargo fmt` + `cargo clippy -- -D warnings` 通過（pre-commit hook）
- 自動セーブ呼び出し 4 箇所 (exit / tui / Ctrl-D / synth 後) は無傷であることを grep / Read で確認

## テスト

純粋な削除タスクであり、削除アーム以外の制御フロー・自動保存ロジックには触れていない（QA 観点整理サブエージェントの判定でも新規テスト不要）。既存 244 テスト全パスで回帰検出は十分。