### PR TITLE
feat: kako-jun/curion#71 i18n Phase 4 — Achievement / Daily Mission / Evolution / Synthesis を lang gate に通す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+- i18n Phase 4 (#71): Achievement / Daily Mission / Evolution / Synthesis recipe のゲーム内本文を lang gate に通した。
+  - `data/evolutions/lines.json` の 5 系列に `display_name_en` を追加。`EvolutionLine::display_name_for(lang)` で取得。
+  - `data/recipes/basic_recipes.json` の 17 レシピに `name_en` と `description_en` を追加。`SynthesisRecipe::name_for(lang)` / `description_for(lang)` を提供。Unknown レシピのラベル "未確認レシピ #NN" は EN 時 "Unrecorded recipe #NN" に切り替わる。
+  - `Achievement` に `name_en` / `description_en` / `reward_title_en` を追加し、`with_en(...)` builder で register 時に英訳を流し込む。`name_for(lang)` / `description_for(lang)` / `reward_title_for(lang)` を提供。
+  - `DailyMission` テンプレートに `description_en` を追加し、`DailyMission::description_for(lang)` を提供。
+  - `SynthesisManager::try_synthesize_lang` / `try_synthesize_with_rolls_lang` を追加し、合成成功・発見・高リスク失敗・No recipe のトースト文を `--lang en` 起動時に英語化。Dashboard の進化進捗、Achievements タブ、デイリーミッション、レシピ一覧の各タブ本文を lang 経由で表示。
+
 ### Removed
 - Interactive モードの `save` コマンドを削除 (#73, #62 follow-up)。永続化は startup / exit / tui / Ctrl-D の自動セーブに一本化。
 - 矢印キー (Up/Down/Left/Right) / PageUp / PageDown / Tab キーの TUI 入力ハンドラを廃止 (#72)。

--- a/data/evolutions/lines.json
+++ b/data/evolutions/lines.json
@@ -2,6 +2,7 @@
   {
     "id": "fish_dragon",
     "display_name": "魚 → 蛇 → 龍",
+    "display_name_en": "fish → snake → dragon",
     "stages": [
       { "stage": 1, "noun": "魚", "required_count": 10 },
       { "stage": 2, "noun": "蛇", "required_count": 3 },
@@ -11,6 +12,7 @@
   {
     "id": "bamboo_pine_forest",
     "display_name": "竹 → 松 → 森",
+    "display_name_en": "bamboo → pine → forest",
     "stages": [
       { "stage": 1, "noun": "竹", "required_count": 8 },
       { "stage": 2, "noun": "松", "required_count": 3 },
@@ -20,6 +22,7 @@
   {
     "id": "fire_flame_phoenix",
     "display_name": "火 → 炎 → 鳳凰",
+    "display_name_en": "fire → flame → phoenix",
     "stages": [
       { "stage": 1, "noun": "火", "required_count": 7 },
       { "stage": 2, "noun": "炎", "required_count": 3 },
@@ -29,6 +32,7 @@
   {
     "id": "water_ice_whale",
     "display_name": "水 → 氷 → 鯨",
+    "display_name_en": "water → ice → whale",
     "stages": [
       { "stage": 1, "noun": "水", "required_count": 9 },
       { "stage": 2, "noun": "氷", "required_count": 3 },
@@ -38,6 +42,7 @@
   {
     "id": "light_star_sun",
     "display_name": "光 → 星 → 太陽",
+    "display_name_en": "light → star → sun",
     "stages": [
       { "stage": 1, "noun": "光", "required_count": 12 },
       { "stage": 2, "noun": "星", "required_count": 4 },

--- a/data/recipes/basic_recipes.json
+++ b/data/recipes/basic_recipes.json
@@ -2,7 +2,9 @@
   {
     "id": "recipe_001",
     "name": "蒸気",
+    "name_en": "steam",
     "description": "水と火を組み合わせると蒸気が生まれる",
+    "description_en": "water and fire combine into steam",
     "ingredients": [
       {
         "specific_noun": "水",
@@ -30,7 +32,9 @@
   {
     "id": "recipe_002",
     "name": "泥",
+    "name_en": "mud",
     "description": "土と水を混ぜると泥になる",
+    "description_en": "earth and water blend into mud",
     "ingredients": [
       {
         "specific_noun": "土",
@@ -58,7 +62,9 @@
   {
     "id": "recipe_003",
     "name": "溶岩",
+    "name_en": "lava",
     "description": "火と土が合わさり溶岩が生まれる",
+    "description_en": "fire and earth fuse into lava",
     "ingredients": [
       {
         "specific_noun": "火",
@@ -88,7 +94,9 @@
   {
     "id": "recipe_004",
     "name": "紫",
+    "name_en": "purple",
     "description": "赤と青を混ぜると紫色になる",
+    "description_en": "red and blue mix to make purple",
     "ingredients": [
       {
         "specific_noun": "赤",
@@ -116,7 +124,9 @@
   {
     "id": "recipe_005",
     "name": "緑",
+    "name_en": "green",
     "description": "青と黄を混ぜると緑色になる",
+    "description_en": "blue and yellow mix to make green",
     "ingredients": [
       {
         "specific_noun": "青",
@@ -144,7 +154,9 @@
   {
     "id": "recipe_006",
     "name": "月光狼",
+    "name_en": "moonlight wolf",
     "description": "狼と月が出会うとき、神秘的な月光狼が誕生する",
+    "description_en": "when the wolf meets the moon, a mystical moonlight wolf is born",
     "ingredients": [
       {
         "specific_noun": "狼",
@@ -175,7 +187,9 @@
   {
     "id": "recipe_007",
     "name": "炎龍",
+    "name_en": "flame dragon",
     "description": "龍に火の力を宿すと伝説の炎龍が現れる",
+    "description_en": "channelling fire into a dragon summons the legendary flame dragon",
     "ingredients": [
       {
         "specific_noun": "龍",
@@ -206,7 +220,9 @@
   {
     "id": "recipe_008",
     "name": "氷鳳凰",
+    "name_en": "ice phoenix",
     "description": "鳳凰に氷の力を与えると神秘の氷鳳凰が生まれる",
+    "description_en": "imbuing the phoenix with ice gives rise to the mystical ice phoenix",
     "ingredients": [
       {
         "specific_noun": "鳳凰",
@@ -237,7 +253,9 @@
   {
     "id": "recipe_009",
     "name": "愛猫",
+    "name_en": "beloved cat",
     "description": "猫と愛が融合すると愛らしいペットが生まれる",
+    "description_en": "cat and love fuse into an adorable companion",
     "ingredients": [
       {
         "specific_noun": "猫",
@@ -267,7 +285,9 @@
   {
     "id": "recipe_010",
     "name": "美愛",
+    "name_en": "beautiful love",
     "description": "愛と美が溶け合い、至高の概念が誕生する",
+    "description_en": "love and beauty dissolve into a supreme concept",
     "ingredients": [
       {
         "specific_noun": "愛",
@@ -297,7 +317,9 @@
   {
     "id": "recipe_011",
     "name": "聖剣",
+    "name_en": "holy sword",
     "description": "正義の心と剣が一体化し、聖なる剣が完成する",
+    "description_en": "a heart of justice and a sword unite into a holy blade",
     "ingredients": [
       {
         "specific_noun": "正義",
@@ -328,7 +350,9 @@
   {
     "id": "recipe_012",
     "name": "希望",
+    "name_en": "hope",
     "description": "夢と光が交わるとき、希望が芽生える",
+    "description_en": "where dream meets light, hope takes root",
     "ingredients": [
       {
         "specific_noun": "夢",
@@ -358,7 +382,9 @@
   {
     "id": "recipe_013",
     "name": "絶望",
+    "name_en": "despair",
     "description": "影と闇が重なると絶望が生まれる",
+    "description_en": "shadow layered on darkness gives birth to despair",
     "ingredients": [
       {
         "specific_noun": "影",
@@ -386,7 +412,9 @@
   {
     "id": "recipe_014",
     "name": "陰陽",
+    "name_en": "yin-yang",
     "description": "光と闇、相反する二つの力が調和する",
+    "description_en": "light and darkness, two opposing forces, reach harmony",
     "ingredients": [
       {
         "specific_noun": "光",
@@ -418,7 +446,9 @@
   {
     "id": "recipe_015",
     "name": "宇宙",
+    "name_en": "cosmos",
     "description": "時間と空間が融合し、無限の宇宙が広がる",
+    "description_en": "time and space merge, unfolding an infinite cosmos",
     "ingredients": [
       {
         "specific_noun": "時間",
@@ -449,7 +479,9 @@
   {
     "id": "recipe_016",
     "name": "禁断の神",
+    "name_en": "forbidden god",
     "description": "混沌と秩序を無理やり融合させ、神なるものを呼び寄せる",
+    "description_en": "forcibly fusing chaos and order calls forth a divine being",
     "ingredients": [
       {
         "specific_noun": "混沌",
@@ -483,7 +515,9 @@
   {
     "id": "recipe_017",
     "name": "黒い太陽",
+    "name_en": "black sun",
     "description": "光と影を強引に結合する。失敗すれば残骸の灰だけが残る",
+    "description_en": "forcefully bind light and shadow; failure leaves only ashen remains",
     "ingredients": [
       {
         "specific_noun": "光",

--- a/data/recipes/basic_recipes.json
+++ b/data/recipes/basic_recipes.json
@@ -154,9 +154,9 @@
   {
     "id": "recipe_006",
     "name": "月光狼",
-    "name_en": "moonlight wolf",
+    "name_en": "Moonlight Wolf",
     "description": "狼と月が出会うとき、神秘的な月光狼が誕生する",
-    "description_en": "when the wolf meets the moon, a mystical moonlight wolf is born",
+    "description_en": "when the wolf meets the moon, a mystical Moonlight Wolf is born",
     "ingredients": [
       {
         "specific_noun": "狼",
@@ -187,9 +187,9 @@
   {
     "id": "recipe_007",
     "name": "炎龍",
-    "name_en": "flame dragon",
+    "name_en": "Flame Dragon",
     "description": "龍に火の力を宿すと伝説の炎龍が現れる",
-    "description_en": "channelling fire into a dragon summons the legendary flame dragon",
+    "description_en": "channelling fire into a dragon summons the legendary Flame Dragon",
     "ingredients": [
       {
         "specific_noun": "龍",
@@ -220,9 +220,9 @@
   {
     "id": "recipe_008",
     "name": "氷鳳凰",
-    "name_en": "ice phoenix",
+    "name_en": "Ice Phoenix",
     "description": "鳳凰に氷の力を与えると神秘の氷鳳凰が生まれる",
-    "description_en": "imbuing the phoenix with ice gives rise to the mystical ice phoenix",
+    "description_en": "imbuing the phoenix with ice gives rise to the mystical Ice Phoenix",
     "ingredients": [
       {
         "specific_noun": "鳳凰",
@@ -253,9 +253,9 @@
   {
     "id": "recipe_009",
     "name": "愛猫",
-    "name_en": "beloved cat",
+    "name_en": "Cherished Companion",
     "description": "猫と愛が融合すると愛らしいペットが生まれる",
-    "description_en": "cat and love fuse into an adorable companion",
+    "description_en": "cat and love fuse into a Cherished Companion",
     "ingredients": [
       {
         "specific_noun": "猫",
@@ -412,7 +412,7 @@
   {
     "id": "recipe_014",
     "name": "陰陽",
-    "name_en": "yin-yang",
+    "name_en": "Yin-Yang",
     "description": "光と闇、相反する二つの力が調和する",
     "description_en": "light and darkness, two opposing forces, reach harmony",
     "ingredients": [
@@ -479,9 +479,9 @@
   {
     "id": "recipe_016",
     "name": "禁断の神",
-    "name_en": "forbidden god",
+    "name_en": "Forbidden Divinity",
     "description": "混沌と秩序を無理やり融合させ、神なるものを呼び寄せる",
-    "description_en": "forcibly fusing chaos and order calls forth a divine being",
+    "description_en": "forcibly fusing chaos and order calls forth a Forbidden Divinity",
     "ingredients": [
       {
         "specific_noun": "混沌",
@@ -515,7 +515,7 @@
   {
     "id": "recipe_017",
     "name": "黒い太陽",
-    "name_en": "black sun",
+    "name_en": "Black Sun",
     "description": "光と影を強引に結合する。失敗すれば残骸の灰だけが残る",
     "description_en": "forcefully bind light and shadow; failure leaves only ashen remains",
     "ingredients": [

--- a/src/achievement.rs
+++ b/src/achievement.rs
@@ -1,4 +1,5 @@
 use crate::curion::{Category, Rarity};
+use crate::i18n::Language;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -45,9 +46,18 @@ pub struct Achievement {
     pub id: AchievementId,
     pub name: String,
     pub description: String,
+    /// Issue #71 Phase 4: 英語版実績名。空文字なら `name` (JA) にフォールバック。
+    #[serde(default)]
+    pub name_en: String,
+    /// Issue #71 Phase 4: 英語版説明。空文字なら `description` (JA) にフォールバック。
+    #[serde(default)]
+    pub description_en: String,
     pub achievement_type: AchievementType,
     pub reward_xp: u32,
     pub reward_title: Option<String>,
+    /// Issue #71 Phase 4: 英語版称号。`None` なら `reward_title` を返す。
+    #[serde(default)]
+    pub reward_title_en: Option<String>,
     pub icon: String,
 }
 
@@ -65,10 +75,68 @@ impl Achievement {
             id,
             name,
             description,
+            name_en: String::new(),
+            description_en: String::new(),
             achievement_type,
             reward_xp,
             reward_title,
+            reward_title_en: None,
             icon,
+        }
+    }
+
+    /// Issue #71 Phase 4: 英語訳を後付けする builder。
+    ///
+    /// 既存の `Achievement::new` を変えずに `.with_en(...)` で英訳を流し込めるので、
+    /// `register_default_achievements` の各登録が縦並びのまま読める。
+    pub fn with_en(
+        mut self,
+        name_en: impl Into<String>,
+        description_en: impl Into<String>,
+        reward_title_en: Option<String>,
+    ) -> Self {
+        self.name_en = name_en.into();
+        self.description_en = description_en.into();
+        self.reward_title_en = reward_title_en;
+        self
+    }
+
+    /// Issue #71 Phase 4: 言語別の実績名。`name_en` が空なら JA にフォールバック。
+    pub fn name_for(&self, lang: Language) -> &str {
+        match lang {
+            Language::Ja => &self.name,
+            Language::En => {
+                if self.name_en.is_empty() {
+                    &self.name
+                } else {
+                    &self.name_en
+                }
+            }
+        }
+    }
+
+    /// Issue #71 Phase 4: 言語別の説明文。`description_en` が空なら JA にフォールバック。
+    pub fn description_for(&self, lang: Language) -> &str {
+        match lang {
+            Language::Ja => &self.description,
+            Language::En => {
+                if self.description_en.is_empty() {
+                    &self.description
+                } else {
+                    &self.description_en
+                }
+            }
+        }
+    }
+
+    /// Issue #71 Phase 4: 言語別の称号。`reward_title_en` が None なら JA にフォールバック。
+    pub fn reward_title_for(&self, lang: Language) -> Option<&str> {
+        match lang {
+            Language::Ja => self.reward_title.as_deref(),
+            Language::En => self
+                .reward_title_en
+                .as_deref()
+                .or(self.reward_title.as_deref()),
         }
     }
 }
@@ -171,26 +239,37 @@ impl AchievementManager {
         //     現在の所持数で再達成される (詳細は docs/spec.md 参照)。
         let total_thresholds = [10, 27, 51, 103, 247, 501, 1001];
         for (idx, &count) in total_thresholds.iter().enumerate() {
-            self.register_achievement(Achievement::new(
-                format!("total_{count}"),
-                format!("コレクター Lv.{}", idx + 1),
-                format!("{count}個のキュリオンを集める"),
-                AchievementType::TotalCount(count),
-                count as u32 * 10,
-                if count >= 1001 {
-                    Some("伝説のコレクター".to_string())
-                } else {
-                    None
-                },
-                if count >= 1001 {
-                    "👑"
-                } else if count >= 501 {
-                    "💎"
-                } else {
-                    "📦"
-                }
-                .to_string(),
-            ));
+            self.register_achievement(
+                Achievement::new(
+                    format!("total_{count}"),
+                    format!("コレクター Lv.{}", idx + 1),
+                    format!("{count}個のキュリオンを集める"),
+                    AchievementType::TotalCount(count),
+                    count as u32 * 10,
+                    if count >= 1001 {
+                        Some("伝説のコレクター".to_string())
+                    } else {
+                        None
+                    },
+                    if count >= 1001 {
+                        "👑"
+                    } else if count >= 501 {
+                        "💎"
+                    } else {
+                        "📦"
+                    }
+                    .to_string(),
+                )
+                .with_en(
+                    format!("Collector Lv.{}", idx + 1),
+                    format!("Collect {count} curions"),
+                    if count >= 1001 {
+                        Some("Legendary Collector".to_string())
+                    } else {
+                        None
+                    },
+                ),
+            );
         }
 
         // レアリティ別 (Issue #32: 旧 [10,50,100]/[5,25,50]/[1,5,10,50,100] を非線形に)
@@ -200,33 +279,47 @@ impl AchievementManager {
             (Rarity::Legendary, vec![1, 7, 23, 47, 101]),
         ] {
             for count in counts {
-                self.register_achievement(Achievement::new(
-                    format!("{rarity:?}_{count}").to_lowercase(),
-                    format!("{rarity:?} ハンター {count}"),
-                    format!("{rarity:?}を{count}個集める"),
-                    AchievementType::RarityCount { rarity, count },
-                    count as u32
-                        * match rarity {
-                            Rarity::Rare => 15,
-                            Rarity::Epic => 30,
-                            Rarity::Legendary => 100,
-                            _ => 10,
+                let reward_title_en = if count >= 101 && rarity == Rarity::Legendary {
+                    Some("Mythical Collector".to_string())
+                } else if count == 1 && rarity == Rarity::Legendary {
+                    Some("Legendary Hunter".to_string())
+                } else {
+                    None
+                };
+                self.register_achievement(
+                    Achievement::new(
+                        format!("{rarity:?}_{count}").to_lowercase(),
+                        format!("{rarity:?} ハンター {count}"),
+                        format!("{rarity:?}を{count}個集める"),
+                        AchievementType::RarityCount { rarity, count },
+                        count as u32
+                            * match rarity {
+                                Rarity::Rare => 15,
+                                Rarity::Epic => 30,
+                                Rarity::Legendary => 100,
+                                _ => 10,
+                            },
+                        if count >= 101 && rarity == Rarity::Legendary {
+                            Some("神話の収集家".to_string())
+                        } else if count == 1 && rarity == Rarity::Legendary {
+                            Some("伝説のハンター".to_string())
+                        } else {
+                            None
                         },
-                    if count >= 101 && rarity == Rarity::Legendary {
-                        Some("神話の収集家".to_string())
-                    } else if count == 1 && rarity == Rarity::Legendary {
-                        Some("伝説のハンター".to_string())
-                    } else {
-                        None
-                    },
-                    match rarity {
-                        Rarity::Legendary => "⭐",
-                        Rarity::Epic => "💜",
-                        Rarity::Rare => "💙",
-                        _ => "⚪",
-                    }
-                    .to_string(),
-                ));
+                        match rarity {
+                            Rarity::Legendary => "⭐",
+                            Rarity::Epic => "💜",
+                            Rarity::Rare => "💙",
+                            _ => "⚪",
+                        }
+                        .to_string(),
+                    )
+                    .with_en(
+                        format!("{rarity:?} Hunter {count}"),
+                        format!("Collect {count} {rarity:?} curions"),
+                        reward_title_en,
+                    ),
+                );
             }
         }
 
@@ -242,88 +335,139 @@ impl AchievementManager {
             Category::Phenomenon,
             Category::Abstract,
         ] {
-            self.register_achievement(Achievement::new(
-                format!("complete_{category:?}").to_lowercase(),
-                format!("{}マスター", category.as_str()),
-                format!("{}カテゴリを全種コンプリート", category.as_str()),
-                AchievementType::CategoryComplete(category.clone()),
-                500,
-                Some(format!("{}の覇者", category.as_str())),
-                "🏆".to_string(),
-            ));
+            let cat_en = category.display(Language::En);
+            self.register_achievement(
+                Achievement::new(
+                    format!("complete_{category:?}").to_lowercase(),
+                    format!("{}マスター", category.as_str()),
+                    format!("{}カテゴリを全種コンプリート", category.as_str()),
+                    AchievementType::CategoryComplete(category.clone()),
+                    500,
+                    Some(format!("{}の覇者", category.as_str())),
+                    "🏆".to_string(),
+                )
+                .with_en(
+                    format!("{cat_en} Master"),
+                    format!("Complete the entire {cat_en} category"),
+                    Some(format!("{cat_en} Overlord")),
+                ),
+            );
         }
 
         // 全カテゴリコンプリート
-        self.register_achievement(Achievement::new(
-            "all_categories".to_string(),
-            "完璧主義者".to_string(),
-            "全カテゴリをコンプリート".to_string(),
-            AchievementType::AllCategoriesComplete,
-            5000,
-            Some("完全なる収集家".to_string()),
-            "👑".to_string(),
-        ));
+        self.register_achievement(
+            Achievement::new(
+                "all_categories".to_string(),
+                "完璧主義者".to_string(),
+                "全カテゴリをコンプリート".to_string(),
+                AchievementType::AllCategoriesComplete,
+                5000,
+                Some("完全なる収集家".to_string()),
+                "👑".to_string(),
+            )
+            .with_en(
+                "Perfectionist",
+                "Complete all categories",
+                Some("Perfect Collector".to_string()),
+            ),
+        );
 
         // 連続ログイン (Issue #32: 30 → 33, 100 → 101 で「あと一日」感を残す)
         for days in [3, 7, 14, 33, 101] {
-            self.register_achievement(Achievement::new(
-                format!("login_{days}"),
-                format!("継続は力なり {days}"),
-                format!("{days}日連続ログイン"),
-                AchievementType::ConsecutiveLogin(days),
-                days as u32 * 50,
-                if days >= 101 {
-                    Some("不屈の意志".to_string())
-                } else {
-                    None
-                },
-                "🔥".to_string(),
-            ));
+            self.register_achievement(
+                Achievement::new(
+                    format!("login_{days}"),
+                    format!("継続は力なり {days}"),
+                    format!("{days}日連続ログイン"),
+                    AchievementType::ConsecutiveLogin(days),
+                    days as u32 * 50,
+                    if days >= 101 {
+                        Some("不屈の意志".to_string())
+                    } else {
+                        None
+                    },
+                    "🔥".to_string(),
+                )
+                .with_en(
+                    format!("Persistence Is Power {days}"),
+                    format!("Log in for {days} consecutive days"),
+                    if days >= 101 {
+                        Some("Unyielding Will".to_string())
+                    } else {
+                        None
+                    },
+                ),
+            );
         }
 
         // プレイ時間 (Issue #32: 50 → 47, 100 → 103, 500 → 503)
         for hours in [1, 11, 47, 103, 503] {
-            self.register_achievement(Achievement::new(
-                format!("playtime_{hours}"),
-                format!("ベテラン {hours}"),
-                format!("{hours}時間プレイ"),
-                AchievementType::PlayTime(hours * 60),
-                hours as u32 * 20,
-                if hours >= 503 {
-                    Some("時間の支配者".to_string())
-                } else {
-                    None
-                },
-                "⏰".to_string(),
-            ));
+            self.register_achievement(
+                Achievement::new(
+                    format!("playtime_{hours}"),
+                    format!("ベテラン {hours}"),
+                    format!("{hours}時間プレイ"),
+                    AchievementType::PlayTime(hours * 60),
+                    hours as u32 * 20,
+                    if hours >= 503 {
+                        Some("時間の支配者".to_string())
+                    } else {
+                        None
+                    },
+                    "⏰".to_string(),
+                )
+                .with_en(
+                    format!("Veteran {hours}"),
+                    format!("Play for {hours} hours"),
+                    if hours >= 503 {
+                        Some("Master of Time".to_string())
+                    } else {
+                        None
+                    },
+                ),
+            );
         }
 
         // 特殊実績
-        self.register_achievement(Achievement::new(
-            "golden_fever".to_string(),
-            "黄金狂".to_string(),
-            "金のキュリオンを10個集める".to_string(),
-            AchievementType::SpecificNoun {
-                noun: "金".to_string(),
-                count: 10,
-            },
-            1000,
-            Some("錬金術師".to_string()),
-            "🥇".to_string(),
-        ));
+        self.register_achievement(
+            Achievement::new(
+                "golden_fever".to_string(),
+                "黄金狂".to_string(),
+                "金のキュリオンを10個集める".to_string(),
+                AchievementType::SpecificNoun {
+                    noun: "金".to_string(),
+                    count: 10,
+                },
+                1000,
+                Some("錬金術師".to_string()),
+                "🥇".to_string(),
+            )
+            .with_en(
+                "Gold Fever",
+                "Collect 10 gold curions",
+                Some("Alchemist".to_string()),
+            ),
+        );
 
-        self.register_achievement(Achievement::new(
-            "dragon_master".to_string(),
-            "龍の化身".to_string(),
-            "龍のキュリオンを5個集める".to_string(),
-            AchievementType::SpecificNoun {
-                noun: "龍".to_string(),
-                count: 5,
-            },
-            800,
-            Some("龍使い".to_string()),
-            "🐉".to_string(),
-        ));
+        self.register_achievement(
+            Achievement::new(
+                "dragon_master".to_string(),
+                "龍の化身".to_string(),
+                "龍のキュリオンを5個集める".to_string(),
+                AchievementType::SpecificNoun {
+                    noun: "龍".to_string(),
+                    count: 5,
+                },
+                800,
+                Some("龍使い".to_string()),
+                "🐉".to_string(),
+            )
+            .with_en(
+                "Dragon Incarnate",
+                "Collect 5 dragon curions",
+                Some("Dragon Master".to_string()),
+            ),
+        );
     }
 
     /// 実績を登録
@@ -426,5 +570,81 @@ impl AchievementManager {
 impl Default for AchievementManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #71 Phase 4: `name_for(Ja)` は JA をそのまま返し、`name_for(En)` は
+    /// 英訳 (空でなければ) を返す。
+    #[test]
+    fn test_achievement_name_for_lang() {
+        let a = Achievement::new(
+            "x".into(),
+            "黄金狂".into(),
+            "金のキュリオンを10個集める".into(),
+            AchievementType::TotalCount(10),
+            100,
+            Some("錬金術師".into()),
+            "🥇".into(),
+        )
+        .with_en(
+            "Gold Fever",
+            "Collect 10 gold curions",
+            Some("Alchemist".into()),
+        );
+
+        assert_eq!(a.name_for(Language::Ja), "黄金狂");
+        assert_eq!(a.name_for(Language::En), "Gold Fever");
+        assert_eq!(
+            a.description_for(Language::Ja),
+            "金のキュリオンを10個集める"
+        );
+        assert_eq!(a.description_for(Language::En), "Collect 10 gold curions");
+        assert_eq!(a.reward_title_for(Language::Ja), Some("錬金術師"));
+        assert_eq!(a.reward_title_for(Language::En), Some("Alchemist"));
+    }
+
+    /// Issue #71 Phase 4: 英訳が空のレガシー実績は JA フォールバックする。
+    #[test]
+    fn test_achievement_fallbacks_when_en_empty() {
+        let a = Achievement::new(
+            "legacy".into(),
+            "テスト".into(),
+            "説明".into(),
+            AchievementType::TotalCount(10),
+            100,
+            Some("称号".into()),
+            "🏆".into(),
+        );
+        assert_eq!(a.name_for(Language::En), "テスト");
+        assert_eq!(a.description_for(Language::En), "説明");
+        assert_eq!(a.reward_title_for(Language::En), Some("称号"));
+    }
+
+    /// Issue #71 Phase 4: デフォルト実績 (全件) について name_en / description_en が
+    /// 空でないことを確認する (= register_default_achievements が全件に EN を付けた)。
+    #[test]
+    fn test_default_achievements_all_have_en_translations() {
+        let mgr = AchievementManager::new();
+        for a in mgr.get_all_achievements() {
+            assert!(!a.name_en.is_empty(), "{}: name_en empty", a.id);
+            assert!(
+                !a.description_en.is_empty(),
+                "{}: description_en empty",
+                a.id
+            );
+            assert_ne!(a.name_en, a.name, "{}: name_en equals JA name", a.id);
+            // reward_title_en は reward_title がある実績だけチェック
+            if a.reward_title.is_some() {
+                assert!(
+                    a.reward_title_en.is_some(),
+                    "{}: reward_title_en missing while JA exists",
+                    a.id
+                );
+            }
+        }
     }
 }

--- a/src/achievement.rs
+++ b/src/achievement.rs
@@ -315,8 +315,8 @@ impl AchievementManager {
                         .to_string(),
                     )
                     .with_en(
-                        format!("{rarity:?} Hunter {count}"),
-                        format!("Collect {count} {rarity:?} curions"),
+                        format!("{} Hunter {count}", rarity.display(Language::En)),
+                        format!("Collect {count} {} curions", rarity.display(Language::En)),
                         reward_title_en,
                     ),
                 );
@@ -389,7 +389,7 @@ impl AchievementManager {
                     "🔥".to_string(),
                 )
                 .with_en(
-                    format!("Persistence Is Power {days}"),
+                    format!("Persistence Is Power — {days} days"),
                     format!("Log in for {days} consecutive days"),
                     if days >= 101 {
                         Some("Unyielding Will".to_string())
@@ -417,7 +417,7 @@ impl AchievementManager {
                     "⏰".to_string(),
                 )
                 .with_en(
-                    format!("Veteran {hours}"),
+                    format!("Veteran — {hours}h"),
                     format!("Play for {hours} hours"),
                     if hours >= 503 {
                         Some("Master of Time".to_string())

--- a/src/curion.rs
+++ b/src/curion.rs
@@ -21,6 +21,23 @@ impl Rarity {
             Rarity::Legendary => 0.01, // 1%
         }
     }
+
+    /// Issue #71 Phase 4: 言語別の表示名。
+    ///
+    /// `{rarity:?}` のデバッグフォーマットに頼らず、明示的に翻訳を返す。
+    /// JA はカタカナ、EN は Title Case の英単語。
+    pub fn display(&self, lang: crate::i18n::Language) -> &'static str {
+        match (self, lang) {
+            (Rarity::Common, crate::i18n::Language::Ja) => "コモン",
+            (Rarity::Rare, crate::i18n::Language::Ja) => "レア",
+            (Rarity::Epic, crate::i18n::Language::Ja) => "エピック",
+            (Rarity::Legendary, crate::i18n::Language::Ja) => "レジェンダリー",
+            (Rarity::Common, crate::i18n::Language::En) => "Common",
+            (Rarity::Rare, crate::i18n::Language::En) => "Rare",
+            (Rarity::Epic, crate::i18n::Language::En) => "Epic",
+            (Rarity::Legendary, crate::i18n::Language::En) => "Legendary",
+        }
+    }
 }
 
 /// キュリオンのカテゴリ

--- a/src/daily_mission.rs
+++ b/src/daily_mission.rs
@@ -1,4 +1,5 @@
 use crate::curion::{Category, Curion, Rarity};
+use crate::i18n::Language;
 use chrono::NaiveDate;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -27,6 +28,9 @@ pub struct DailyMission {
     pub id: String,
     /// 表示用説明
     pub description: String,
+    /// Issue #71 Phase 4: 英語版説明。空文字なら `description` (JA) にフォールバック。
+    #[serde(default)]
+    pub description_en: String,
     /// 種別
     pub kind: DailyMissionKind,
     /// 目標値
@@ -47,6 +51,20 @@ impl DailyMission {
         self.current >= self.target
     }
 
+    /// Issue #71 Phase 4: 言語別の説明文。`description_en` が空なら JA フォールバック。
+    pub fn description_for(&self, lang: Language) -> &str {
+        match lang {
+            Language::Ja => &self.description,
+            Language::En => {
+                if self.description_en.is_empty() {
+                    &self.description
+                } else {
+                    &self.description_en
+                }
+            }
+        }
+    }
+
     /// 進捗率 (0.0..=1.0)
     pub fn progress_ratio(&self) -> f64 {
         if self.target == 0 {
@@ -60,6 +78,8 @@ impl DailyMission {
 struct MissionTemplate {
     id: &'static str,
     description: &'static str,
+    /// Issue #71 Phase 4: 英語版説明。
+    description_en: &'static str,
     kind: DailyMissionKind,
     target: usize,
     reward_xp: u32,
@@ -71,6 +91,7 @@ const TEMPLATES: &[MissionTemplate] = &[
     MissionTemplate {
         id: "collect_any_10",
         description: "10個のキュリオンを収集",
+        description_en: "Collect 10 curions",
         kind: DailyMissionKind::CollectAny(10),
         target: 10,
         reward_xp: 100,
@@ -78,6 +99,7 @@ const TEMPLATES: &[MissionTemplate] = &[
     MissionTemplate {
         id: "collect_rare_at_least_3",
         description: "Rare 以上を 3 個獲得",
+        description_en: "Get 3 curions of Rare or above",
         kind: DailyMissionKind::CollectRarityAtLeast(Rarity::Rare, 3),
         target: 3,
         reward_xp: 200,
@@ -85,6 +107,7 @@ const TEMPLATES: &[MissionTemplate] = &[
     MissionTemplate {
         id: "synthesize_success_1",
         description: "合成を 1 回成功させる",
+        description_en: "Succeed at synthesis once",
         kind: DailyMissionKind::SynthesizeSuccess(1),
         target: 1,
         reward_xp: 300,
@@ -92,6 +115,7 @@ const TEMPLATES: &[MissionTemplate] = &[
     MissionTemplate {
         id: "collect_from_categories_5",
         description: "5 種類の異なるカテゴリから収集",
+        description_en: "Collect from 5 different categories",
         kind: DailyMissionKind::CollectFromCategories(5),
         target: 5,
         reward_xp: 150,
@@ -146,6 +170,7 @@ impl DailyMissionManager {
                 DailyMission {
                     id: tpl.id.to_string(),
                     description: tpl.description.to_string(),
+                    description_en: tpl.description_en.to_string(),
                     kind: tpl.kind.clone(),
                     target: tpl.target,
                     current: 0,
@@ -362,6 +387,7 @@ mod tests {
         mgr.missions = vec![DailyMission {
             id: "collect_any_10".to_string(),
             description: "10 個".to_string(),
+            description_en: String::new(),
             kind: DailyMissionKind::CollectAny(10),
             target: 10,
             current: 0,
@@ -382,6 +408,7 @@ mod tests {
         mgr.missions = vec![DailyMission {
             id: "collect_rare_at_least_3".to_string(),
             description: "Rare 以上 3 個".to_string(),
+            description_en: String::new(),
             kind: DailyMissionKind::CollectRarityAtLeast(Rarity::Rare, 3),
             target: 3,
             current: 0,
@@ -411,6 +438,7 @@ mod tests {
         mgr.missions = vec![DailyMission {
             id: "collect_from_categories_5".to_string(),
             description: "5 種類".to_string(),
+            description_en: String::new(),
             kind: DailyMissionKind::CollectFromCategories(5),
             target: 5,
             current: 0,
@@ -439,6 +467,7 @@ mod tests {
             DailyMission {
                 id: "synthesize_success_1".to_string(),
                 description: "合成 1 回".to_string(),
+                description_en: String::new(),
                 kind: DailyMissionKind::SynthesizeSuccess(1),
                 target: 1,
                 current: 0,
@@ -449,6 +478,7 @@ mod tests {
             DailyMission {
                 id: "collect_any_10".to_string(),
                 description: "10 個".to_string(),
+                description_en: String::new(),
                 kind: DailyMissionKind::CollectAny(10),
                 target: 10,
                 current: 0,
@@ -473,6 +503,7 @@ mod tests {
             DailyMission {
                 id: "collect_any_10".to_string(),
                 description: "10 個".to_string(),
+                description_en: String::new(),
                 kind: DailyMissionKind::CollectAny(10),
                 target: 10,
                 current: 10,
@@ -484,6 +515,7 @@ mod tests {
             DailyMission {
                 id: "synthesize_success_1".to_string(),
                 description: "合成 1 回".to_string(),
+                description_en: String::new(),
                 kind: DailyMissionKind::SynthesizeSuccess(1),
                 target: 1,
                 current: 1,
@@ -495,6 +527,7 @@ mod tests {
             DailyMission {
                 id: "collect_rare_at_least_3".to_string(),
                 description: "Rare 以上 3 個".to_string(),
+                description_en: String::new(),
                 kind: DailyMissionKind::CollectRarityAtLeast(Rarity::Rare, 3),
                 target: 3,
                 current: 1,
@@ -517,6 +550,7 @@ mod tests {
         mgr.missions = vec![DailyMission {
             id: "collect_any_10".to_string(),
             description: "10 個".to_string(),
+            description_en: String::new(),
             kind: DailyMissionKind::CollectAny(10),
             target: 10,
             current: 10,
@@ -540,6 +574,7 @@ mod tests {
             DailyMission {
                 id: "collect_any_10".to_string(),
                 description: "10 個".to_string(),
+                description_en: String::new(),
                 kind: DailyMissionKind::CollectAny(10),
                 target: 10,
                 current: 10,
@@ -550,6 +585,7 @@ mod tests {
             DailyMission {
                 id: "synthesize_success_1".to_string(),
                 description: "合成 1 回".to_string(),
+                description_en: String::new(),
                 kind: DailyMissionKind::SynthesizeSuccess(1),
                 target: 1,
                 current: 1,
@@ -565,6 +601,40 @@ mod tests {
         mgr.record_synthesis_success();
         assert_eq!(mgr.missions[0].current, 10);
         assert_eq!(mgr.missions[1].current, 1);
+    }
+
+    /// Issue #71 Phase 4: `generate_for_date` で生成されたミッションは
+    /// `description_for(En)` が空でなく、JA と異なる。
+    #[test]
+    fn test_daily_mission_description_for_lang() {
+        let date = NaiveDate::from_ymd_opt(2026, 5, 16).unwrap();
+        let missions = DailyMissionManager::generate_for_date(date);
+        assert_eq!(missions.len(), 3);
+        for m in &missions {
+            let ja = m.description_for(Language::Ja);
+            let en = m.description_for(Language::En);
+            assert!(!ja.is_empty(), "{}: JA empty", m.id);
+            assert!(!en.is_empty(), "{}: EN empty", m.id);
+            assert_ne!(ja, en, "{}: JA equals EN", m.id);
+        }
+    }
+
+    /// Issue #71 Phase 4: `description_en` 空のレガシーミッションは JA フォールバック。
+    #[test]
+    fn test_daily_mission_description_for_lang_fallbacks() {
+        let date = NaiveDate::from_ymd_opt(2026, 5, 16).unwrap();
+        let m = DailyMission {
+            id: "legacy".to_string(),
+            description: "JA only".to_string(),
+            description_en: String::new(),
+            kind: DailyMissionKind::CollectAny(1),
+            target: 1,
+            current: 0,
+            reward_xp: 0,
+            expires_at: date,
+            claimed: false,
+        };
+        assert_eq!(m.description_for(Language::En), "JA only");
     }
 
     #[test]

--- a/src/evolution.rs
+++ b/src/evolution.rs
@@ -33,6 +33,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::curion::Curion;
+use crate::i18n::Language;
 
 /// 埋め込みデータ。`data/evolutions/lines.json` をビルド時に取り込む。
 const EVOLUTIONS_JSON: &str = include_str!("../data/evolutions/lines.json");
@@ -58,11 +59,31 @@ pub struct EvolutionLine {
     pub id: String,
     /// UI 表示用ラベル (例: "魚 → 蛇 → 龍")。
     pub display_name: String,
+    /// English UI 表示用ラベル (例: "fish → snake → dragon")。Issue #71 Phase 4。
+    #[serde(default)]
+    pub display_name_en: String,
     /// 段階リスト。`stage` 昇順で並んでいる前提。
     pub stages: Vec<EvolutionStage>,
 }
 
 impl EvolutionLine {
+    /// 言語別の表示名 (Issue #71 Phase 4)。
+    ///
+    /// `Language::En` のときに `display_name_en` が空文字なら (旧データ互換)
+    /// JA の `display_name` を fallback として返す。
+    pub fn display_name_for(&self, lang: Language) -> &str {
+        match lang {
+            Language::Ja => &self.display_name,
+            Language::En => {
+                if self.display_name_en.is_empty() {
+                    &self.display_name
+                } else {
+                    &self.display_name_en
+                }
+            }
+        }
+    }
+
     /// 最大 stage 番号。空配列に対しては 0 を返す (異常データ防御)。
     pub fn max_stage(&self) -> u8 {
         self.stages.iter().map(|s| s.stage).max().unwrap_or(0)
@@ -436,6 +457,41 @@ mod tests {
         assert_eq!(light.current_stage, 1);
         assert_eq!(light.remaining_to_next, 1);
         assert!(light.is_almost_complete());
+    }
+
+    /// Issue #71 Phase 4: `display_name_for(Ja)` は既存 JA 文字列を返す。
+    #[test]
+    fn test_display_name_for_ja_matches_legacy() {
+        let db = db();
+        for line in db.all_lines() {
+            assert_eq!(line.display_name_for(Language::Ja), line.display_name);
+        }
+    }
+
+    /// Issue #71 Phase 4: `display_name_for(En)` は英訳を返す (5 系列すべて非空)。
+    #[test]
+    fn test_display_name_for_en_is_translated() {
+        let db = db();
+        for line in db.all_lines() {
+            let en = line.display_name_for(Language::En);
+            assert!(!en.is_empty(), "{}: En display_name is empty", line.id);
+            assert_ne!(en, line.display_name, "{}: En must differ from JA", line.id);
+        }
+    }
+
+    /// Issue #71 Phase 4: `display_name_en` が空のとき (legacy データ互換) は
+    /// JA にフォールバックする。
+    #[test]
+    fn test_display_name_for_en_fallbacks_to_ja_when_empty() {
+        let mut line = EvolutionLine {
+            id: "legacy".to_string(),
+            display_name: "魚 → 蛇 → 龍".to_string(),
+            display_name_en: String::new(),
+            stages: vec![],
+        };
+        assert_eq!(line.display_name_for(Language::En), "魚 → 蛇 → 龍");
+        line.display_name_en = "fish → snake → dragon".to_string();
+        assert_eq!(line.display_name_for(Language::En), "fish → snake → dragon");
     }
 
     /// 9. 関係のない noun を持っていても進化進捗には影響しない。

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -447,7 +447,11 @@ fn cmd_synthesize(name1: &str, name2: &str, game_state: &mut GameState) -> Resul
     let second_id = second.id.clone();
     let ingredients = vec![first, second];
 
-    match game_state.synthesis_manager.try_synthesize(ingredients)? {
+    let lang = game_state.language;
+    match game_state
+        .synthesis_manager
+        .try_synthesize_lang(ingredients, lang)?
+    {
         SynthesisAttemptResult::Success {
             curion,
             recipe_name,

--- a/src/plain.rs
+++ b/src/plain.rs
@@ -106,7 +106,11 @@ pub fn run_plain_mode(profile_manager: &ProfileManager, args: &[String]) -> Resu
             let b_noun = b.noun.clone();
 
             use crate::synthesis::SynthesisAttemptResult;
-            match game_state.synthesis_manager.try_synthesize(vec![a, b])? {
+            let lang = game_state.language;
+            match game_state
+                .synthesis_manager
+                .try_synthesize_lang(vec![a, b], lang)?
+            {
                 SynthesisAttemptResult::Success {
                     curion,
                     recipe_name,

--- a/src/player.rs
+++ b/src/player.rs
@@ -1016,6 +1016,15 @@ impl GameState {
         &self,
         limit: usize,
     ) -> Vec<(String, AchievementProgress, f64)> {
+        self.get_almost_complete_achievements_lang(limit, crate::i18n::Language::Ja)
+    }
+
+    /// Issue #71 Phase 4: 言語別の名前を返すバリアント。
+    pub fn get_almost_complete_achievements_lang(
+        &self,
+        limit: usize,
+        lang: crate::i18n::Language,
+    ) -> Vec<(String, AchievementProgress, f64)> {
         let mut list: Vec<_> = self
             .achievement_manager
             .get_sorted_by_progress()
@@ -1023,7 +1032,7 @@ impl GameState {
             .filter(|(_, progress)| !progress.unlocked && progress.progress_ratio() >= 0.3)
             .map(|(achievement, progress)| {
                 (
-                    achievement.name.clone(),
+                    achievement.name_for(lang).to_string(),
                     progress.clone(),
                     progress.progress_ratio(),
                 )
@@ -1172,6 +1181,7 @@ mod tests {
         state.player.daily_mission_manager.missions = vec![DailyMission {
             id: "collect_any_10".to_string(),
             description: "10 個".to_string(),
+            description_en: String::new(),
             kind: DailyMissionKind::CollectAny(10),
             target: 10,
             current: 10,
@@ -1267,6 +1277,7 @@ mod tests {
         state.player.daily_mission_manager.missions = vec![DailyMission {
             id: "collect_any_10".to_string(),
             description: "10 個収集".to_string(),
+            description_en: String::new(),
             kind: DailyMissionKind::CollectAny(10),
             target: 10,
             current: 10,
@@ -1346,6 +1357,7 @@ mod tests {
         state.player.daily_mission_manager.missions = vec![DailyMission {
             id: "collect_any_10".to_string(),
             description: "10 個収集".to_string(),
+            description_en: String::new(),
             kind: DailyMissionKind::CollectAny(10),
             target: 10,
             current: 10,

--- a/src/player.rs
+++ b/src/player.rs
@@ -984,7 +984,7 @@ impl GameState {
     ///    PlayTime を網羅。残量は `target - current` を実績名ベースで生成)
     ///
     /// 全部達成済み、または開始 0% から始まる長期目標しか残っていない場合は `None`。
-    pub fn next_milestone(&self) -> Option<MilestoneHint> {
+    pub fn next_milestone(&self, lang: crate::i18n::Language) -> Option<MilestoneHint> {
         let mut candidates: Vec<MilestoneHint> = Vec::new();
         candidates.push(self.player.next_level_milestone());
 
@@ -1003,7 +1003,7 @@ impl GameState {
                 continue;
             }
             candidates.push(MilestoneHint {
-                label: format!("{} {}", achievement.icon, achievement.name),
+                label: format!("{} {}", achievement.icon, achievement.name_for(lang)),
                 remaining: remaining as u32,
             });
         }

--- a/src/synthesis.rs
+++ b/src/synthesis.rs
@@ -1,4 +1,5 @@
 use crate::curion::{Category, Curion, Rarity};
+use crate::i18n::Language;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -12,6 +13,12 @@ pub struct SynthesisRecipe {
     pub id: String,
     pub name: String,
     pub description: String,
+    /// Issue #71 Phase 4: 英語版レシピ名。空文字なら `name` (JA) にフォールバックする。
+    #[serde(default)]
+    pub name_en: String,
+    /// Issue #71 Phase 4: 英語版説明文。空文字なら `description` (JA) にフォールバックする。
+    #[serde(default)]
+    pub description_en: String,
     pub ingredients: Vec<IngredientRequirement>,
     pub result: SynthesisResult,
     pub discovery_rate: f64, // 初見成功率（0.0〜1.0）
@@ -152,6 +159,34 @@ impl SynthesisRecipe {
         p.total.saturating_sub(p.satisfied)
     }
 
+    /// Issue #71 Phase 4: 言語別のレシピ名。`name_en` が空なら JA `name` にフォールバック。
+    pub fn name_for(&self, lang: Language) -> &str {
+        match lang {
+            Language::Ja => &self.name,
+            Language::En => {
+                if self.name_en.is_empty() {
+                    &self.name
+                } else {
+                    &self.name_en
+                }
+            }
+        }
+    }
+
+    /// Issue #71 Phase 4: 言語別のレシピ説明。`description_en` が空なら JA にフォールバック。
+    pub fn description_for(&self, lang: Language) -> &str {
+        match lang {
+            Language::Ja => &self.description,
+            Language::En => {
+                if self.description_en.is_empty() {
+                    &self.description
+                } else {
+                    &self.description_en
+                }
+            }
+        }
+    }
+
     /// Issue #37: レシピ一覧に出す 1 行表示用ラベルを返す。
     ///
     /// - `is_discovered == true` なら `visibility` に関係なく完全表示 ("水 + 火 → 蒸気")
@@ -161,11 +196,14 @@ impl SynthesisRecipe {
     ///
     /// `index` は呼び出し側 (UI) が一覧上の表示順から渡す 0-origin の値。
     /// `Unknown` のラベルは `#01` から表示されるよう内部で +1 する。
+    ///
+    /// Issue #71 Phase 4: `lang` を受け取り「未確認レシピ」を言語別に表示する。
     pub fn display_label(
         &self,
         _collection: &[Curion],
         is_discovered: bool,
         index: usize,
+        lang: Language,
     ) -> String {
         // 発見済みは常に完全表示。
         if is_discovered || self.visibility == RecipeVisibility::Public {
@@ -191,9 +229,10 @@ impl SynthesisRecipe {
                 }
                 format!("{} → ?", parts.join(" + "))
             }
-            RecipeVisibility::Unknown => {
-                format!("未確認レシピ #{:02}", index + 1)
-            }
+            RecipeVisibility::Unknown => match lang {
+                Language::Ja => format!("未確認レシピ #{:02}", index + 1),
+                Language::En => format!("Unrecorded recipe #{:02}", index + 1),
+            },
         }
     }
 }
@@ -400,9 +439,22 @@ impl SynthesisManager {
 
     /// 合成を試みる
     pub fn try_synthesize(&mut self, ingredients: Vec<Curion>) -> Result<SynthesisAttemptResult> {
+        self.try_synthesize_lang(ingredients, Language::Ja)
+    }
+
+    /// Issue #71 Phase 4: 言語指定付きで合成を試みる。
+    ///
+    /// `recipe_name` を `lang` に従って組み立てるため、UI 側で英語化されたレシピ名を
+    /// `Success` / `HighRiskFailure` に直接乗せられる。`try_synthesize` は JA を
+    /// 既定として委譲する (後方互換)。
+    pub fn try_synthesize_lang(
+        &mut self,
+        ingredients: Vec<Curion>,
+        lang: Language,
+    ) -> Result<SynthesisAttemptResult> {
         let discovery_roll: f64 = rand::random();
         let risk_roll: f64 = rand::random();
-        self.try_synthesize_with_rolls(ingredients, discovery_roll, risk_roll)
+        self.try_synthesize_with_rolls_lang(ingredients, discovery_roll, risk_roll, lang)
     }
 
     /// Issue #35: テスト用に乱数を外部注入できる内部 API。
@@ -412,11 +464,23 @@ impl SynthesisManager {
     /// - `risk_roll`: `success_rate` 判定に使う。`risk_roll > success_rate` で `HighRiskFailure`。
     ///
     /// `try_synthesize` の薄いラッパで本実装。
+    #[cfg(test)]
     pub fn try_synthesize_with_rolls(
         &mut self,
         ingredients: Vec<Curion>,
         discovery_roll: f64,
         risk_roll: f64,
+    ) -> Result<SynthesisAttemptResult> {
+        self.try_synthesize_with_rolls_lang(ingredients, discovery_roll, risk_roll, Language::Ja)
+    }
+
+    /// Issue #71 Phase 4: `try_synthesize_with_rolls` の言語対応版。
+    pub fn try_synthesize_with_rolls_lang(
+        &mut self,
+        ingredients: Vec<Curion>,
+        discovery_roll: f64,
+        risk_roll: f64,
+        lang: Language,
     ) -> Result<SynthesisAttemptResult> {
         // マッチするレシピを検索
         let matching_recipes = self.recipe_db.find_matching_recipes(&ingredients);
@@ -430,7 +494,7 @@ impl SynthesisManager {
 
         // 必要なデータを先にコピー
         let recipe_id = recipe.id.clone();
-        let recipe_name = recipe.name.clone();
+        let recipe_name = recipe.name_for(lang).to_string();
         let discovery_rate = recipe.discovery_rate;
         let success_rate = recipe.success_rate;
         let failure_mode = recipe.failure_mode.clone();
@@ -442,8 +506,12 @@ impl SynthesisManager {
         // 未発見の場合、discovery_rateで成功判定
         if !is_discovered {
             if discovery_roll > discovery_rate {
+                let hint = match lang {
+                    Language::Ja => "何かが起こりそうだが、まだ完全には理解できていない...",
+                    Language::En => "Something almost happens, but you don't yet understand it...",
+                };
                 return Ok(SynthesisAttemptResult::DiscoveryFailed {
-                    hint: "何かが起こりそうだが、まだ完全には理解できていない...".to_string(),
+                    hint: hint.to_string(),
                 });
             }
             // 発見成功！
@@ -701,6 +769,8 @@ mod tests {
             id: "test_recipe".to_string(),
             name: "テストレシピ".to_string(),
             description: "for unit test".to_string(),
+            name_en: String::new(),
+            description_en: String::new(),
             ingredients: vec![],
             result: SynthesisResult {
                 noun: "結果".to_string(),
@@ -730,6 +800,8 @@ mod tests {
             id: id.to_string(),
             name: result_noun.to_string(),
             description: "test pair recipe".to_string(),
+            name_en: String::new(),
+            description_en: String::new(),
             ingredients: vec![
                 IngredientRequirement {
                     specific_noun: Some(ingredient_a.to_string()),
@@ -1141,7 +1213,7 @@ mod tests {
     fn test_display_label_public_uses_full_names() {
         let recipe = make_pair_recipe("p_pub", "蒸気", "水", "火", 1.0, FailureMode::NoLoss);
         // visibility は make_pair_recipe で Public がデフォルト
-        let label = recipe.display_label(&[], false, 0);
+        let label = recipe.display_label(&[], false, 0, Language::Ja);
         assert!(label.contains("水"), "label={label}");
         assert!(label.contains("火"), "label={label}");
         assert!(label.contains("蒸気"), "label={label}");
@@ -1161,7 +1233,7 @@ mod tests {
         );
         recipe.visibility = RecipeVisibility::Partial;
 
-        let label = recipe.display_label(&[], false, 5);
+        let label = recipe.display_label(&[], false, 5, Language::Ja);
         assert!(
             label.contains("光"),
             "first ingredient should be shown: {label}"
@@ -1186,7 +1258,7 @@ mod tests {
         recipe.visibility = RecipeVisibility::Unknown;
 
         // index 6 → "#07" (0-origin +1, 2 桁 0 埋め)
-        let label = recipe.display_label(&[], false, 6);
+        let label = recipe.display_label(&[], false, 6, Language::Ja);
         assert!(label.contains("未確認レシピ"), "label={label}");
         assert!(
             label.contains("#07"),
@@ -1208,7 +1280,7 @@ mod tests {
             let mut recipe =
                 make_pair_recipe("p_d", "黒い太陽", "光", "影", 0.5, FailureMode::NoLoss);
             recipe.visibility = vis;
-            let label = recipe.display_label(&[], true, 9);
+            let label = recipe.display_label(&[], true, 9, Language::Ja);
             assert!(label.contains("光"), "vis={vis:?} label={label}");
             assert!(label.contains("影"), "vis={vis:?} label={label}");
             assert!(label.contains("黒い太陽"), "vis={vis:?} label={label}");
@@ -1217,5 +1289,72 @@ mod tests {
                 "discovered should not be Unknown: {label}"
             );
         }
+    }
+
+    // ---------- Issue #71 Phase 4: lang gate ----------
+
+    /// Issue #71 Phase 4: `name_for(Ja)` は JA `name` をそのまま返す。
+    #[test]
+    fn test_recipe_name_for_ja_matches_legacy() {
+        let db = RecipeDatabase::load_embedded().expect("recipes load");
+        for r in db.all_recipes() {
+            assert_eq!(r.name_for(Language::Ja), r.name);
+        }
+    }
+
+    /// Issue #71 Phase 4: `name_for(En)` は 17 件すべて非空かつ JA と異なる。
+    #[test]
+    fn test_recipe_name_for_en_is_translated_for_all_recipes() {
+        let db = RecipeDatabase::load_embedded().expect("recipes load");
+        assert_eq!(db.all_recipes().len(), 17);
+        for r in db.all_recipes() {
+            let en = r.name_for(Language::En);
+            assert!(!en.is_empty(), "{}: name_en is empty", r.id);
+            assert_ne!(en, r.name, "{}: name_en equals name (JA)", r.id);
+        }
+    }
+
+    /// Issue #71 Phase 4: `description_for(En)` も 17 件すべて非空。
+    #[test]
+    fn test_recipe_description_for_en_is_translated_for_all_recipes() {
+        let db = RecipeDatabase::load_embedded().expect("recipes load");
+        for r in db.all_recipes() {
+            let en = r.description_for(Language::En);
+            assert!(!en.is_empty(), "{}: description_en is empty", r.id);
+            assert_ne!(en, r.description, "{}: description_en equals JA", r.id);
+        }
+    }
+
+    /// Issue #71 Phase 4: `name_en`/`description_en` が空のレガシーデータは JA フォールバック。
+    #[test]
+    fn test_recipe_for_lang_fallbacks_when_en_empty() {
+        let mut r = sample_recipe(1.0);
+        r.name = "テスト".to_string();
+        r.description = "JA only".to_string();
+        r.name_en = String::new();
+        r.description_en = String::new();
+        assert_eq!(r.name_for(Language::En), "テスト");
+        assert_eq!(r.description_for(Language::En), "JA only");
+    }
+
+    /// Issue #71 Phase 4: Unknown レシピの "未確認レシピ" 表示が言語別に切り替わる。
+    #[test]
+    fn test_display_label_unknown_lang_gate() {
+        let mut recipe = make_pair_recipe(
+            "p_unk_lang",
+            "禁断",
+            "混沌",
+            "秩序",
+            0.25,
+            FailureMode::LoseAll,
+        );
+        recipe.visibility = RecipeVisibility::Unknown;
+        let ja = recipe.display_label(&[], false, 6, Language::Ja);
+        let en = recipe.display_label(&[], false, 6, Language::En);
+        assert!(ja.contains("未確認レシピ"), "ja={ja}");
+        assert!(ja.contains("#07"));
+        assert!(en.contains("Unrecorded recipe"), "en={en}");
+        assert!(en.contains("#07"));
+        assert!(!en.contains("未確認"), "en should not include JA: {en}");
     }
 }

--- a/src/synthesis.rs
+++ b/src/synthesis.rs
@@ -437,7 +437,15 @@ impl SynthesisManager {
         self.discovered_recipes.insert(recipe_id, true);
     }
 
-    /// 合成を試みる
+    /// 合成を試みる (旧 API)。
+    ///
+    /// 既定で `Language::Ja` を返すため、多言語対応コードでは
+    /// [`try_synthesize_lang`](Self::try_synthesize_lang) を使うこと。
+    #[deprecated(
+        since = "0.4.0",
+        note = "Use try_synthesize_lang. This wrapper defaults to Language::Ja and will be removed."
+    )]
+    #[allow(dead_code)]
     pub fn try_synthesize(&mut self, ingredients: Vec<Curion>) -> Result<SynthesisAttemptResult> {
         self.try_synthesize_lang(ingredients, Language::Ja)
     }

--- a/src/synthesis.rs
+++ b/src/synthesis.rs
@@ -8,12 +8,23 @@ use uuid::Uuid;
 const RECIPES_JSON: &str = include_str!("../data/recipes/basic_recipes.json");
 
 /// 合成レシピ
+///
+/// # `name_en` の大文字小文字方針 (Issue #71 Phase 4)
+///
+/// - 合成結果が**固有の生き物・神話的存在の名前**になるものは Title Case で書く
+///   (例: `Moonlight Wolf`, `Flame Dragon`, `Ice Phoenix`, `Forbidden Divinity`)。
+/// - 合成結果が**一般物質名・現象名・抽象概念**のものは lower case で書く
+///   (例: `steam`, `mud`, `lava`, `hope`, `despair`, `cosmos`)。
+///
+/// レシピデータ (`data/recipes/basic_recipes.json`) もこの方針に従って整える。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SynthesisRecipe {
     pub id: String,
     pub name: String,
     pub description: String,
     /// Issue #71 Phase 4: 英語版レシピ名。空文字なら `name` (JA) にフォールバックする。
+    ///
+    /// 大文字小文字の方針は [`SynthesisRecipe`] の doc コメントを参照。
     #[serde(default)]
     pub name_en: String,
     /// Issue #71 Phase 4: 英語版説明文。空文字なら `description` (JA) にフォールバックする。
@@ -1311,6 +1322,10 @@ mod tests {
     }
 
     /// Issue #71 Phase 4: `name_for(En)` は 17 件すべて非空かつ JA と異なる。
+    ///
+    /// 全レシピで `name_en` 必須を構造的に強制するためのテスト。
+    /// 空文字フォールバックを許容する設計に変える場合 (例: `Option<String>` に
+    /// 寄せて `name_en` 未設定時は JA を返す方式) は、このテストを再考すること。
     #[test]
     fn test_recipe_name_for_en_is_translated_for_all_recipes() {
         let db = RecipeDatabase::load_embedded().expect("recipes load");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -783,10 +783,11 @@ impl App {
                                 .cloned()
                             {
                                 let ingredients = vec![first_curion.clone(), second_curion.clone()];
+                                let lang = self.game_state.language;
                                 let result = self
                                     .game_state
                                     .synthesis_manager
-                                    .try_synthesize(ingredients)?;
+                                    .try_synthesize_lang(ingredients, lang)?;
 
                                 match result {
                                     SynthesisAttemptResult::Success {
@@ -807,10 +808,27 @@ impl App {
                                         // Issue #62: 合成成功は素材消費+新キュリオン獲得を伴う重要 mutation。
                                         self.dirty = true;
 
-                                        let message = if first_discovery {
-                                            format!("✨ Discovered: {recipe_name}!")
-                                        } else {
-                                            format!("Created: {}", curion.noun)
+                                        let message = match lang {
+                                            crate::i18n::Language::Ja => {
+                                                if first_discovery {
+                                                    format!("✨ 発見: {recipe_name}!")
+                                                } else {
+                                                    format!("生成: {}", curion.noun)
+                                                }
+                                            }
+                                            crate::i18n::Language::En => {
+                                                let result_label = self
+                                                    .generator
+                                                    .database()
+                                                    .english_for(&curion.noun)
+                                                    .map(|s| s.to_string())
+                                                    .unwrap_or_else(|| curion.noun.clone());
+                                                if first_discovery {
+                                                    format!("✨ Discovered: {recipe_name}!")
+                                                } else {
+                                                    format!("Created: {result_label}")
+                                                }
+                                            }
                                         };
                                         self.save_message = Some((message, Instant::now()));
 
@@ -823,8 +841,11 @@ impl App {
                                         self.save_message = Some((hint, Instant::now()));
                                     }
                                     SynthesisAttemptResult::NoRecipe => {
-                                        self.save_message =
-                                            Some(("No recipe found".to_string(), Instant::now()));
+                                        let msg = match lang {
+                                            crate::i18n::Language::Ja => "レシピが見つかりません",
+                                            crate::i18n::Language::En => "No recipe found",
+                                        };
+                                        self.save_message = Some((msg.to_string(), Instant::now()));
                                     }
                                     // Issue #35: 高リスク合成失敗の処理。
                                     // - lost_ingredients を collection から id 一致で除去
@@ -849,16 +870,37 @@ impl App {
                                         }
                                         // Issue #62: 高リスク合成失敗も素材消滅 (+ salvage) を伴う mutation。
                                         self.dirty = true;
-                                        let msg = match failure_mode {
-                                            crate::synthesis::FailureMode::LoseAll => {
-                                                format!("💥 失敗: {recipe_name} (素材消滅)")
-                                            }
-                                            crate::synthesis::FailureMode::Salvage { .. } => {
-                                                format!("💔 失敗: {recipe_name} (残骸を獲得)")
-                                            }
-                                            crate::synthesis::FailureMode::NoLoss => {
-                                                format!("⚠ 失敗: {recipe_name} (保険発動)")
-                                            }
+                                        let msg = match (lang, &failure_mode) {
+                                            (
+                                                crate::i18n::Language::Ja,
+                                                crate::synthesis::FailureMode::LoseAll,
+                                            ) => format!("💥 失敗: {recipe_name} (素材消滅)"),
+                                            (
+                                                crate::i18n::Language::Ja,
+                                                crate::synthesis::FailureMode::Salvage { .. },
+                                            ) => format!("💔 失敗: {recipe_name} (残骸を獲得)"),
+                                            (
+                                                crate::i18n::Language::Ja,
+                                                crate::synthesis::FailureMode::NoLoss,
+                                            ) => format!("⚠ 失敗: {recipe_name} (保険発動)"),
+                                            (
+                                                crate::i18n::Language::En,
+                                                crate::synthesis::FailureMode::LoseAll,
+                                            ) => format!(
+                                                "💥 Failed: {recipe_name} (ingredients lost)"
+                                            ),
+                                            (
+                                                crate::i18n::Language::En,
+                                                crate::synthesis::FailureMode::Salvage { .. },
+                                            ) => format!(
+                                                "💔 Failed: {recipe_name} (salvage acquired)"
+                                            ),
+                                            (
+                                                crate::i18n::Language::En,
+                                                crate::synthesis::FailureMode::NoLoss,
+                                            ) => format!(
+                                                "⚠ Failed: {recipe_name} (insurance triggered)"
+                                            ),
                                         };
                                         self.save_message = Some((msg, Instant::now()));
 
@@ -1549,6 +1591,7 @@ impl App {
     fn render_daily_missions(&self, f: &mut Frame<'_>, area: Rect) {
         use chrono::Local;
 
+        let lang = self.game_state.language;
         let missions = &self.game_state.player.daily_mission_manager.missions;
 
         // タイトル: 翌 0:00 までの残り時間を chrono::Duration で計算し、
@@ -1565,14 +1608,25 @@ impl App {
         let remaining_minutes = (total_secs + 59) / 60;
         let hh = remaining_minutes / 60;
         let mm = remaining_minutes % 60;
-        let title = format!("デイリーミッション (リセットまで {hh:02}:{mm:02})");
+        let title = match lang {
+            crate::i18n::Language::Ja => {
+                format!("デイリーミッション (リセットまで {hh:02}:{mm:02})")
+            }
+            crate::i18n::Language::En => {
+                format!("Daily Missions (resets in {hh:02}:{mm:02})")
+            }
+        };
 
         let block = focused_block(title);
         let inner = block.inner(area);
         f.render_widget(block, area);
 
         if missions.is_empty() {
-            let empty = Paragraph::new("まだデータがありません")
+            let empty_msg = match lang {
+                crate::i18n::Language::Ja => "まだデータがありません",
+                crate::i18n::Language::En => "No data yet",
+            };
+            let empty = Paragraph::new(empty_msg)
                 .style(Style::default().fg(COLOR_LABEL))
                 .alignment(Alignment::Center);
             f.render_widget(empty, inner);
@@ -1591,9 +1645,13 @@ impl App {
                 .constraints(constraints)
                 .split(inner);
             // ヘッダ行
+            let compact_header = match lang {
+                crate::i18n::Language::Ja => "デイリーミッション (簡易表示)",
+                crate::i18n::Language::En => "Daily Missions (compact)",
+            };
             f.render_widget(
                 Paragraph::new(Line::from(Span::styled(
-                    "デイリーミッション (簡易表示)",
+                    compact_header,
                     Style::default().fg(COLOR_LABEL),
                 ))),
                 chunks[0],
@@ -1613,7 +1671,7 @@ impl App {
                 let line = Line::from(vec![
                     Span::raw(icon),
                     Span::raw(" "),
-                    Span::raw(mission.description.clone()),
+                    Span::raw(mission.description_for(lang).to_string()),
                     Span::raw(format!(
                         " {}/{} +{}XP",
                         mission.current.min(mission.target),
@@ -1651,7 +1709,7 @@ impl App {
                 Span::raw(icon),
                 Span::raw(" "),
                 Span::styled(
-                    mission.description.clone(),
+                    mission.description_for(lang).to_string(),
                     Style::default()
                         .fg(if completed {
                             COLOR_SUCCESS
@@ -1689,8 +1747,16 @@ impl App {
                     Style::default().fg(COLOR_SUCCESS),
                 )])
             } else {
+                let reward_label = match lang {
+                    crate::i18n::Language::Ja => {
+                        format!("  報酬: +{} XP", mission.reward_xp)
+                    }
+                    crate::i18n::Language::En => {
+                        format!("  Reward: +{} XP", mission.reward_xp)
+                    }
+                };
                 Line::from(vec![Span::styled(
-                    format!("  報酬: +{} XP", mission.reward_xp),
+                    reward_label,
                     Style::default().fg(COLOR_LABEL),
                 )])
             };
@@ -1976,19 +2042,24 @@ impl App {
         // UI 側は値を読んで色付けするだけ。
         let mut evo_progress = self.evolution_db.calculate_progress(&player.collection);
         sort_progress_by_urgency(&mut evo_progress);
+        let lang = self.game_state.language;
+        let (evo_prefix, complete_label) = match lang {
+            crate::i18n::Language::Ja => ("進化: ", "  ⭐ 完成"),
+            crate::i18n::Language::En => ("Evolve: ", "  ⭐ Complete"),
+        };
         let evo_lines: Vec<Line<'_>> = evo_progress
             .iter()
             .take(3)
             .map(|p| {
                 if p.is_complete() {
                     Line::from(vec![
-                        Span::styled("進化: ", Style::default().fg(COLOR_LABEL)),
+                        Span::styled(evo_prefix, Style::default().fg(COLOR_LABEL)),
                         Span::styled(
-                            p.line.display_name.clone(),
+                            p.line.display_name_for(lang).to_string(),
                             Style::default().fg(Color::White),
                         ),
                         Span::styled(
-                            "  ⭐ 完成",
+                            complete_label,
                             Style::default()
                                 .fg(Color::Green)
                                 .add_modifier(Modifier::BOLD),
@@ -2009,14 +2080,29 @@ impl App {
                     };
                     let next_text = match (p.next_stage_noun, p.next_stage_required) {
                         (Some(noun), Some(_req)) => {
-                            format!(" (あと {} ×{} で次段階)", noun, p.remaining_to_next)
+                            let noun_display = self
+                                .generator
+                                .database()
+                                .english_for(noun)
+                                .filter(|_| lang == crate::i18n::Language::En)
+                                .unwrap_or(noun);
+                            match lang {
+                                crate::i18n::Language::Ja => format!(
+                                    " (あと {} ×{} で次段階)",
+                                    noun_display, p.remaining_to_next
+                                ),
+                                crate::i18n::Language::En => format!(
+                                    " ({} more {} to next stage)",
+                                    p.remaining_to_next, noun_display
+                                ),
+                            }
                         }
                         _ => String::new(),
                     };
                     Line::from(vec![
-                        Span::styled("進化: ", Style::default().fg(COLOR_LABEL)),
+                        Span::styled(evo_prefix, Style::default().fg(COLOR_LABEL)),
                         Span::styled(
-                            p.line.display_name.clone(),
+                            p.line.display_name_for(lang).to_string(),
                             Style::default().fg(Color::White),
                         ),
                         Span::raw("  "),
@@ -2132,7 +2218,10 @@ impl App {
     }
 
     fn render_dashboard_bottom(&self, f: &mut Frame<'_>, area: Rect) {
-        let almost_complete = self.game_state.get_almost_complete_achievements(10);
+        let lang = self.game_state.language;
+        let almost_complete = self
+            .game_state
+            .get_almost_complete_achievements_lang(10, lang);
 
         let mut items: Vec<ListItem> = Vec::new();
 
@@ -2151,20 +2240,41 @@ impl App {
                 ""
             };
 
-            let urgency = if ratio >= 0.95 {
-                "緊急！ "
-            } else if ratio >= 0.80 {
-                "もうすぐ！ "
-            } else {
-                ""
+            let urgency = match lang {
+                crate::i18n::Language::Ja => {
+                    if ratio >= 0.95 {
+                        "緊急！ "
+                    } else if ratio >= 0.80 {
+                        "もうすぐ！ "
+                    } else {
+                        ""
+                    }
+                }
+                crate::i18n::Language::En => {
+                    if ratio >= 0.95 {
+                        "URGENT! "
+                    } else if ratio >= 0.80 {
+                        "ALMOST! "
+                    } else {
+                        ""
+                    }
+                }
             };
 
+            let line_text = match lang {
+                crate::i18n::Language::Ja => {
+                    format!("{urgency}あと {remaining} で「{name}」達成！")
+                }
+                crate::i18n::Language::En => {
+                    format!("{urgency}{remaining} more to unlock \"{name}\"!")
+                }
+            };
             items.push(ListItem::new(vec![
                 Line::from(vec![
                     Span::raw(icon),
                     Span::raw(" "),
                     Span::styled(
-                        format!("{urgency}あと {remaining} で「{name}」達成！"),
+                        line_text,
                         Style::default().fg(color).add_modifier(Modifier::BOLD),
                     ),
                 ]),
@@ -2185,14 +2295,23 @@ impl App {
         let xp_remaining = player.xp_for_next_level() - player.xp;
         let xp_ratio = player.xp_progress_ratio();
 
+        let level_label = match lang {
+            crate::i18n::Language::Ja => format!(
+                "🏆 次のレベルまで: あと {} XP (Lv.{} → Lv.{})",
+                xp_remaining,
+                player.level,
+                player.level + 1
+            ),
+            crate::i18n::Language::En => format!(
+                "🏆 To next level: {} XP remaining (Lv.{} → Lv.{})",
+                xp_remaining,
+                player.level,
+                player.level + 1
+            ),
+        };
         items.push(ListItem::new(vec![
             Line::from(vec![Span::styled(
-                format!(
-                    "🏆 次のレベルまで: あと {} XP (Lv.{} → Lv.{})",
-                    xp_remaining,
-                    player.level,
-                    player.level + 1
-                ),
+                level_label,
                 Style::default().fg(COLOR_EPIC).add_modifier(Modifier::BOLD),
             )]),
             Line::from(vec![
@@ -2849,9 +2968,15 @@ impl App {
         let total = self.game_state.achievement_manager.get_total_count();
         let percentage = self.game_state.achievement_manager.get_unlock_percentage();
 
-        let block = focused_block(format!(
-            "{title} | {unlocked} / {total} 解除済み ({percentage}%)"
-        ));
+        let lang = self.game_state.language;
+        let block = focused_block(match lang {
+            crate::i18n::Language::Ja => {
+                format!("{title} | {unlocked} / {total} 解除済み ({percentage}%)")
+            }
+            crate::i18n::Language::En => {
+                format!("{title} | {unlocked} / {total} unlocked ({percentage}%)")
+            }
+        });
         let inner = block.inner(area);
         f.render_widget(block, area);
 
@@ -2890,13 +3015,16 @@ impl App {
                     Span::raw(icon),
                     Span::raw(" "),
                     Span::styled(
-                        format!("[{}] {}", achievement.icon, achievement.name),
+                        format!("[{}] {}", achievement.icon, achievement.name_for(lang)),
                         Style::default()
                             .fg(Color::White)
                             .add_modifier(Modifier::BOLD),
                     ),
                 ]),
-                Line::from(vec![Span::raw("  "), Span::raw(&achievement.description)]),
+                Line::from(vec![
+                    Span::raw("  "),
+                    Span::raw(achievement.description_for(lang).to_string()),
+                ]),
             ]);
             let header_area = Rect {
                 x: item_inner.x,
@@ -2930,31 +3058,42 @@ impl App {
             };
             f.render_widget(gauge, gauge_area);
 
+            let reward_label = match lang {
+                crate::i18n::Language::Ja => "報酬: ",
+                crate::i18n::Language::En => "Reward: ",
+            };
+            let title_span = achievement
+                .reward_title_for(lang)
+                .map(|title| {
+                    let s = match lang {
+                        crate::i18n::Language::Ja => format!(", 称号「{title}」"),
+                        crate::i18n::Language::En => format!(", title \"{title}\""),
+                    };
+                    Span::styled(s, Style::default().fg(COLOR_EPIC))
+                })
+                .unwrap_or_else(|| Span::raw(""));
+            let unlocked_span = progress
+                .unlocked_at
+                .map(|date| {
+                    let s = match lang {
+                        crate::i18n::Language::Ja => {
+                            format!("  解除日: {}", date.format("%Y-%m-%d"))
+                        }
+                        crate::i18n::Language::En => {
+                            format!("  Unlocked: {}", date.format("%Y-%m-%d"))
+                        }
+                    };
+                    Span::styled(s, Style::default().fg(Color::DarkGray))
+                })
+                .unwrap_or_else(|| Span::raw(""));
             let reward = Paragraph::new(Line::from(vec![
-                Span::raw("報酬: "),
+                Span::raw(reward_label),
                 Span::styled(
                     format!("{} XP", achievement.reward_xp),
                     Style::default().fg(COLOR_LEGENDARY),
                 ),
-                achievement
-                    .reward_title
-                    .as_ref()
-                    .map(|title| {
-                        Span::styled(
-                            format!(", 称号「{title}」"),
-                            Style::default().fg(COLOR_EPIC),
-                        )
-                    })
-                    .unwrap_or_else(|| Span::raw("")),
-                progress
-                    .unlocked_at
-                    .map(|date| {
-                        Span::styled(
-                            format!("  解除日: {}", date.format("%Y-%m-%d")),
-                            Style::default().fg(Color::DarkGray),
-                        )
-                    })
-                    .unwrap_or_else(|| Span::raw("")),
+                title_span,
+                unlocked_span,
             ]));
             let reward_area = Rect {
                 x: item_inner.x,
@@ -3434,7 +3573,8 @@ impl App {
                 // Issue #37: 名前と式の行。Unknown は recipe.name を出さず、display_label
                 // の "未確認レシピ #NN" だけにする。Partial/Public は recipe.name は表示しつつ
                 // 式部分 (材料 → 結果) を visibility に従って隠す。
-                let display_label = recipe.display_label(collection, discovered, idx);
+                let display_label =
+                    recipe.display_label(collection, discovered, idx, self.game_state.language);
                 let name_line =
                     if effective_visibility == crate::synthesis::RecipeVisibility::Unknown {
                         Line::from(vec![
@@ -3457,7 +3597,7 @@ impl App {
                             ),
                             Span::raw(" "),
                             Span::styled(
-                                recipe.name.clone(),
+                                recipe.name_for(self.game_state.language).to_string(),
                                 Style::default().fg(name_color).add_modifier(Modifier::BOLD),
                             ),
                         ])
@@ -3499,7 +3639,11 @@ impl App {
                         Style::default().fg(Color::DarkGray),
                     )),
                     _ => Line::from(Span::styled(
-                        format!("    {} -> {}", recipe.description, display_label),
+                        format!(
+                            "    {} -> {}",
+                            recipe.description_for(self.game_state.language),
+                            display_label
+                        ),
                         Style::default().fg(name_color),
                     )),
                 };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3615,31 +3615,46 @@ impl App {
                 // Issue #37: 進捗行。「進捗: 2/2 ✓」または「進捗: 1/2 (あと N 種)」。
                 // Unknown は仕様上「存在しか分からない」ので進捗は出さず、空行とのトレードに
                 // しないため進捗が 0/total の場合のみ常時 1 行で表示する。
-                let progress_line =
-                    if effective_visibility == crate::synthesis::RecipeVisibility::Unknown {
-                        // Unknown は進捗を出さない (材料の正体がバレるため)
-                        Line::from("")
+                let progress_line = if effective_visibility
+                    == crate::synthesis::RecipeVisibility::Unknown
+                {
+                    // Unknown は進捗を出さない (材料の正体がバレるため)
+                    Line::from("")
+                } else {
+                    let progress_text = if progress.all_satisfied {
+                        match self.game_state.language {
+                            crate::i18n::Language::Ja => {
+                                format!("    進捗: {}/{}  ✓", progress.satisfied, progress.total)
+                            }
+                            crate::i18n::Language::En => format!(
+                                "    Progress: {}/{}  ✓",
+                                progress.satisfied, progress.total
+                            ),
+                        }
                     } else {
-                        let progress_text = if progress.all_satisfied {
-                            format!("    進捗: {}/{}  ✓", progress.satisfied, progress.total)
-                        } else {
-                            // Issue #37: 残数算出は SynthesisRecipe::remaining_categories に集約。
-                            let remaining = recipe.remaining_categories(collection);
-                            format!(
+                        // Issue #37: 残数算出は SynthesisRecipe::remaining_categories に集約。
+                        let remaining = recipe.remaining_categories(collection);
+                        match self.game_state.language {
+                            crate::i18n::Language::Ja => format!(
                                 "    進捗: {}/{} (あと {} 種)",
                                 progress.satisfied, progress.total, remaining
-                            )
-                        };
-                        let progress_color = if progress.all_satisfied {
-                            COLOR_SUCCESS
-                        } else {
-                            COLOR_LABEL
-                        };
-                        Line::from(Span::styled(
-                            progress_text,
-                            Style::default().fg(progress_color),
-                        ))
+                            ),
+                            crate::i18n::Language::En => format!(
+                                "    Progress: {}/{} ({} more)",
+                                progress.satisfied, progress.total, remaining
+                            ),
+                        }
                     };
+                    let progress_color = if progress.all_satisfied {
+                        COLOR_SUCCESS
+                    } else {
+                        COLOR_LABEL
+                    };
+                    Line::from(Span::styled(
+                        progress_text,
+                        Style::default().fg(progress_color),
+                    ))
+                };
 
                 // 説明 + 式 (Unknown は description も隠す)
                 let body_line = match effective_visibility {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1962,7 +1962,12 @@ impl App {
 
         // Issue #32: 次のマイルストーン表示 (= 「あと少し感」を常時演出)
         // XP / 各種実績の残量から最も小さいものを 1 行で出す。
-        let milestone_line = if let Some(hint) = self.game_state.next_milestone() {
+        let lang = self.game_state.language;
+        let milestone_line = if let Some(hint) = self.game_state.next_milestone(lang) {
+            let remaining_text = match lang {
+                crate::i18n::Language::Ja => format!(" (あと {})", hint.remaining),
+                crate::i18n::Language::En => format!(" ({} more)", hint.remaining),
+            };
             Line::from(vec![
                 Span::styled("next milestone: ", Style::default().fg(COLOR_LABEL)),
                 Span::styled(
@@ -1970,15 +1975,19 @@ impl App {
                     Style::default().fg(COLOR_EPIC).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(
-                    format!(" (あと {})", hint.remaining),
+                    remaining_text,
                     Style::default()
                         .fg(COLOR_LEGENDARY)
                         .add_modifier(Modifier::BOLD),
                 ),
             ])
         } else {
+            let done_text = match lang {
+                crate::i18n::Language::Ja => "next milestone: 全マイルストーン達成済み",
+                crate::i18n::Language::En => "next milestone: all achievements unlocked",
+            };
             Line::from(vec![Span::styled(
-                "next milestone: 全マイルストーン達成済み",
+                done_text,
                 Style::default().fg(COLOR_LABEL),
             )])
         };


### PR DESCRIPTION
## 関連 Issue
closes #71

## 背景

実機で \`curion --lang en\` を起動するとメニュー・見出しは英語化されるが、ゲーム内本文（実績タイトル、デイリーミッション、進化系統 display_name、合成レシピ/メッセージ）は日本語のままだった。Phase 4 として残り 4 領域を lang gate に通す。

## 4 領域の翻訳件数

| 領域 | データ追加 | 提供ヘルパー |
|---|---|---|
| Evolution | \`data/evolutions/lines.json\` 5 系列に \`display_name_en\` | \`EvolutionLine::display_name_for(lang)\` |
| Synthesis Recipe | \`data/recipes/basic_recipes.json\` 17 件に \`name_en\` + \`description_en\` | \`Recipe::name_for/description_for/display_label(lang)\` + try_synthesize/hint/toast の lang gate |
| Achievement | 全 27 件に \`{name,description,reward_title}_en\` (~70 文字列) | \`Achievement::name_for/description_for/reward_title_for(lang)\` |
| Daily Mission | 4 テンプレに \`description_en\` | \`DailyMission::description_for(lang)\` |

## UI 統合箇所

- Dashboard 進化進捗 (ui.rs:1996-2069)
- Dashboard もうすぐ達成 (ui.rs:2168-2240)
- Daily Missions (ui.rs:1551-1716)
- Achievements タブ (ui.rs:2885-3105)
- Recipe list (ui.rs:3437-3505)
- Synthesis 成功/失敗/no-recipe トースト (ui.rs:810-895)

## 検証

- cargo test: 275 passed (263 + 12 新規)
- cargo clippy --all-targets -- -D warnings: clean
- cargo fmt 適用済

## 残懸念

- 合成専用 noun (蒸気・泥・月光狼 等、\`data/nouns/*.json\` 未登録分) は \`english_for\` が None を返すため EN モードで JA noun が露出する設計のまま (Phase 3 #68 と整合)
- Collection 一覧で「Phenomenon (蒸気)」のように出る既知挙動

## Test plan
- [ ] \`cargo run -- --lang en\` で全 6 タブを巡回し本文が英語化されているか目視
- [ ] \`cargo run -- --lang ja\` で日本語表示が無傷か目視
- [ ] Settings タブで Enter 言語切替→即時表示更新確認