### PR TITLE
docs: kako-jun/curion#71 spec/design に Phase 4 i18n を追記

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -300,6 +300,8 @@ Each achievement card (6 lines height, unfocused_block border):
   Line 2:   Description text
   Line 3: LineGauge: [████░░░░] 75% (15/20) — Green when complete, Gray in progress
   Line 4: 報酬: N XP, 称号「...」 (Legendary/Epic), 解除日: YYYY-MM-DD (DarkGray)
+          (En mode: "Reward: N XP, title \"...\", Unlocked: YYYY-MM-DD" — routed through
+           `Achievement::name_for / description_for / reward_title_for(lang)` since #71 Phase 4)
   Lines 5-6: (padding/blank)
 
 - 達成可能: unlocked && !claimed (ready to claim with Enter)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -45,6 +45,21 @@ Noun data is stored in `data/nouns/*.json` (one file per category). Each entry h
 | `flavor` | yes | Japanese flavor text (SF / philosophical short prose). |
 | `flavor_en` | yes (since #65 Phase 2) | English flavor text. Phase 3 (Issue #68) will route flavor rendering through the language gate; until then the UI always displays `flavor`. |
 
+### Phase 4 (Issue #71): Content i18n
+
+In addition to noun `english` / `flavor_en`, the following game-content fields carry an `_en` variant and are accessed through `*_for(lang)` helpers so the TUI renders the active `Language` consistently:
+
+- `EvolutionLine.display_name_en` (`data/evolutions/lines.json`, 5 entries) — accessed via `EvolutionLine::display_name_for(lang)`.
+- `SynthesisRecipe.name_en` / `description_en` (`data/recipes/basic_recipes.json`, 17 entries) — accessed via `Recipe::name_for(lang)` / `description_for(lang)` / `display_label(_, _, lang)`.
+- `Achievement.name_en` / `description_en` / `reward_title_en` (27 achievements registered in `src/achievement.rs`) — accessed via `Achievement::name_for(lang)` / `description_for(lang)` / `reward_title_for(lang)`.
+- `MissionTemplate.description_en` / `DailyMission.description_en` (4 templates in `src/daily_mission.rs`) — accessed via `DailyMission::description_for(lang)`.
+
+All `_en` fields are deserialized with `#[serde(default)]` (or default `String::new()` for templates) and the `*_for(lang)` helpers fall back to the JA variant when the `_en` value is empty, keeping older saves and data files forward-compatible.
+
+The legacy `SynthesisManager::try_synthesize` (no `lang`) is `#[deprecated]` since v0.4.0; new call sites must use `try_synthesize_lang(_, language)` so synthesis success / failure / discovery hints surface in the active language.
+
+`Recipe.name_en` follows a casing rule: mythical or proper-noun results (e.g. `Flame Dragon`, `Moonlight Wolf`, `Yin-Yang`, `Forbidden Divinity`) use Title Case; common substances (`steam`, `mud`, `lava`) stay lower case.
+
 Synthesis-only nouns generated at runtime (e.g. `蒸気`, `残骸`) may not have an entry in this database, in which case English lookups fall back to the JA noun.
 
 ## Latent Vector Pipeline (Issue #39)


### PR DESCRIPTION
## 関連 Issue
ref #71 (PR #79 マージ後の docs フォローアップ)

## 背景

PR #79 で Phase 4 を実装・マージしたが、`docs/spec.md` と `docs/design.md` は Phase 3 (#68) までしか言及しておらず、Phase 4 で追加された以下のフィールド・ヘルパーが文書化されていなかった:

- `EvolutionLine.display_name_en` + `display_name_for(lang)`
- `Recipe.name_en` / `description_en` + `name_for/description_for/display_label(lang)`
- `Achievement.{name,description,reward_title}_en` + `_for(lang)` ヘルパー
- `MissionTemplate.description_en` / `DailyMission.description_for(lang)`
- `try_synthesize_lang` の deprecation 方針
- `name_en` の casing ルール (固有名詞は Title Case、一般物質名は lower case)

## 変更

- `docs/spec.md` の Phase 2 表記直後に「Phase 4 (Issue #71): Content i18n」セクションを追加
- `docs/design.md` の Achievements タブ Line 4 説明に EN モードの一行を追記