### PR TITLE
feat: kako-jun/curion#68 i18n Phase 3 — flavor 表示の lang gate + interest/curiosity 表記統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - `docs/design.md` をルート直下の `DESIGN.md` に戻した。他リポ (selona / open-sen / osaka-kenpo / xmj 等) の慣習に合わせ、UI デザインシステム文書はリポルート直下 `DESIGN.md` に置く方針で統一。v0.2.0 で `docs/` 配下に移したが、ルートに集約する形に揃え直した。内容変更なし。
 
 ### Added
+- i18n Phase 3 (#68): flavor 表示を lang gate に通した + flavor_en の語彙統一。
+  - `NounEntry` に `flavor_en` フィールドを追加 (JSON 側は #65 Phase 2 で既に追加済) し、`NounDatabase::flavor_for(noun, lang)` を lang 引数付きに拡張。EN 時は `flavor_en` を返し、空文字または未設定なら JA `flavor` にフォールバック (Phase 4 同パターン)。合成専用 noun (`蒸気` / `残骸` 等) は従来通り None。
+  - UI の flavor 表示 2 箇所 (Collection 詳細ペイン / Dictionary 図鑑エントリ) を `flavor_for(noun, game_state.language)` 経由に切替。`--lang en` 時の JA flavor 漏出を解消。詳細ペインの未登録プレースホルダも EN 時 `(no flavor)` に切替。
+  - `data/nouns/*.json` の `flavor_en` 内で curiosity 同義に使われていた `interest` を `curiosity` に統一 (abstracts: 52 件 / animals: 59 件 / foods: 2 件)。リポ名 `curion` (= curiosity) との表記整合を最大化。英語慣用句 `point of interest` 等は対象外だがデータ中に存在しなかった。
 - i18n Phase 4 (#71): Achievement / Daily Mission / Evolution / Synthesis recipe のゲーム内本文を lang gate に通した。
   - `data/evolutions/lines.json` の 5 系列に `display_name_en` を追加。`EvolutionLine::display_name_for(lang)` で取得。
   - `data/recipes/basic_recipes.json` の 17 レシピに `name_en` と `description_en` を追加。`SynthesisRecipe::name_for(lang)` / `description_for(lang)` を提供。Unknown レシピのラベル "未確認レシピ #NN" は EN 時 "Unrecorded recipe #NN" に切り替わる。

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -249,7 +249,7 @@ Right pane layout:
   - Timestamp: DarkGray
   - Detail pane (Issue #22 + #27): unfocused_block("詳細: {noun}") with two body lines for
     the curion currently at the top of the visible list. `Wrap { trim: true }` is applied.
-    Line 1: SF flavor text (Color::Gray); missing flavor falls back to `(フレーバー未登録)`.
+    Line 1: SF flavor text (Color::Gray), routed through `NounDatabase::flavor_for(noun, game_state.language)` so EN sessions render `flavor_en` (Issue #68 Phase 3a). Missing flavor falls back to `(フレーバー未登録)` (JA) / `(no flavor)` (EN).
     Line 2 (Issue #27, Color::DarkGray): acquisition history —
       `入手: YYYY-MM-DD HH:MM  (通算 N回目の収集)`, where the timestamp is rendered in the
       local TZ. Legacy save curions without `acquisition_index` show `(履歴情報なし)`.
@@ -264,7 +264,9 @@ Right pane layout:
         Acquired: "noun        ★★   [RARE] YYYY-MM-DD ×count"
                   (rarity color on stars+label, white bold noun, DarkGray date,
                    COLOR_SUCCESS count)
-                  Flavor line (Issue #22, only when acquired and flavor is present):
+                  Flavor line (Issue #22, only when acquired and flavor is present;
+                  Issue #68 Phase 3a routes selection through
+                  `NounDatabase::flavor_for(noun, game_state.language)` for EN/JA):
                   "  {flavor}" (indented 2 cells, COLOR_LABEL = DarkGray).
                   If the flavor exceeds inner width, it is truncated at display-cell
                   width and `…` is appended (see `truncate_display`).

--- a/data/nouns/abstracts.json
+++ b/data/nouns/abstracts.json
@@ -5,7 +5,7 @@
     "english": "love",
     "weight": 1.0,
     "flavor": "観測者と対象を区別しなくなる、結合の興味を宿す粒子。万有引力の心理学的形態。",
-    "flavor_en": "A particle bearing the interest of union, where observer and object cease to be distinguished. A psychological form of universal gravitation."
+    "flavor_en": "A particle bearing the curiosity of union, where observer and object cease to be distinguished. A psychological form of universal gravitation."
   },
   {
     "name": "美",
@@ -13,7 +13,7 @@
     "english": "beauty",
     "weight": 1.0,
     "flavor": "認識した瞬間に呼吸を変える、調和の興味を宿す粒子。理由を超えて魂を立ち止まらせる。",
-    "flavor_en": "A particle bearing the interest of harmony, altering one's breath at the moment of recognition. It halts the soul beyond reason."
+    "flavor_en": "A particle bearing the curiosity of harmony, altering one's breath at the moment of recognition. It halts the soul beyond reason."
   },
   {
     "name": "自由",
@@ -21,7 +21,7 @@
     "english": "freedom",
     "weight": 1.0,
     "flavor": "選択肢の総和ではなく選び抜く力、解放の興味の粒子。重みに耐えられる者にだけ宿る。",
-    "flavor_en": "A particle of the interest of liberation, not the sum of choices but the power to choose through. It dwells only in those who can bear its weight."
+    "flavor_en": "A particle of the curiosity of liberation, not the sum of choices but the power to choose through. It dwells only in those who can bear its weight."
   },
   {
     "name": "勇気",
@@ -29,7 +29,7 @@
     "english": "courage",
     "weight": 1.0,
     "flavor": "恐れを抱えたまま前へ進む、決断の興味を宿す粒子。震える手のまま剣を握れる強さ。",
-    "flavor_en": "A particle bearing the interest of decision, advancing while still holding fear. The strength to grasp the sword with a trembling hand."
+    "flavor_en": "A particle bearing the curiosity of decision, advancing while still holding fear. The strength to grasp the sword with a trembling hand."
   },
   {
     "name": "希望",
@@ -37,7 +37,7 @@
     "english": "hope",
     "weight": 1.0,
     "flavor": "暗闇の中で発光する、微小だが切れない興味の粒子。今ここを未来から照らしてくる。",
-    "flavor_en": "A minute yet unbreakable particle of interest, luminescent within the darkness. It illuminates the here and now from the future."
+    "flavor_en": "A minute yet unbreakable particle of curiosity, luminescent within the darkness. It illuminates the here and now from the future."
   },
   {
     "name": "絶望",
@@ -45,7 +45,7 @@
     "english": "despair",
     "weight": 0.7,
     "flavor": "希望の対極に位置する、深淵の興味の粒子。底まで沈むことで反転の合図を放つ。",
-    "flavor_en": "A particle of abyssal interest, positioned opposite to hope. By sinking to the bottom, it emits the signal of reversal."
+    "flavor_en": "A particle of abyssal curiosity, positioned opposite to hope. By sinking to the bottom, it emits the signal of reversal."
   },
   {
     "name": "正義",
@@ -53,7 +53,7 @@
     "english": "justice",
     "weight": 1.0,
     "flavor": "誰の視点に立つかで形が変わる、揺らぐ興味の粒子。問い続ける姿勢こそが本質となる。",
-    "flavor_en": "A wavering particle of interest whose form shifts with whose viewpoint one assumes. The posture of ceaseless questioning is its true essence."
+    "flavor_en": "A wavering particle of curiosity whose form shifts with whose viewpoint one assumes. The posture of ceaseless questioning is its true essence."
   },
   {
     "name": "知恵",
@@ -61,7 +61,7 @@
     "english": "wisdom",
     "weight": 1.0,
     "flavor": "知識を経験で炊き上げた、滋養ある興味の粒子。本ではなく沈黙の中で熟成される。",
-    "flavor_en": "A nourishing particle of interest, knowledge slow-cooked through experience. It matures not in books but within silence."
+    "flavor_en": "A nourishing particle of curiosity, knowledge slow-cooked through experience. It matures not in books but within silence."
   },
   {
     "name": "力",
@@ -69,7 +69,7 @@
     "english": "power",
     "weight": 1.0,
     "flavor": "意志と物質を結ぶ、媒介の興味を宿す粒子。向きを誤れば破壊、定めれば創造となる。",
-    "flavor_en": "A particle bearing the interest of mediation, binding will to matter. Misdirected it becomes destruction; aimed true, creation."
+    "flavor_en": "A particle bearing the curiosity of mediation, binding will to matter. Misdirected it becomes destruction; aimed true, creation."
   },
   {
     "name": "平和",
@@ -77,7 +77,7 @@
     "english": "peace",
     "weight": 1.0,
     "flavor": "騒がしさが収まった後に立ち上る、繊細な興味の粒子。維持するほうが手に入れるより難しい。",
-    "flavor_en": "A delicate particle of interest, rising after the clamor subsides. It is harder to sustain than to attain."
+    "flavor_en": "A delicate particle of curiosity, rising after the clamor subsides. It is harder to sustain than to attain."
   },
   {
     "name": "調和",
@@ -85,7 +85,7 @@
     "english": "harmony",
     "weight": 1.0,
     "flavor": "違うものが共存する音、橋渡しの興味を宿す粒子。同質ではなく差異の中にこそ宿る。",
-    "flavor_en": "A particle bearing the interest of mediation, the sound of differing things coexisting. It dwells not in sameness but within difference itself."
+    "flavor_en": "A particle bearing the curiosity of mediation, the sound of differing things coexisting. It dwells not in sameness but within difference itself."
   },
   {
     "name": "混沌",
@@ -93,7 +93,7 @@
     "english": "chaos",
     "weight": 0.6,
     "flavor": "秩序が生まれる前の母なる海、創発の興味の粒子。曖昧さが新しい形を孕んでいく。",
-    "flavor_en": "A particle of emergent interest, the maternal sea before order is born. Within its ambiguity, new forms are conceived."
+    "flavor_en": "A particle of emergent curiosity, the maternal sea before order is born. Within its ambiguity, new forms are conceived."
   },
   {
     "name": "秩序",
@@ -101,7 +101,7 @@
     "english": "order",
     "weight": 0.8,
     "flavor": "混沌に意味の梁を渡す、構造の興味を宿す粒子。維持するための摩擦も常に伴う。",
-    "flavor_en": "A particle bearing the interest of structure, laying beams of meaning across chaos. Its maintenance always entails friction."
+    "flavor_en": "A particle bearing the curiosity of structure, laying beams of meaning across chaos. Its maintenance always entails friction."
   },
   {
     "name": "真実",
@@ -109,7 +109,7 @@
     "english": "truth",
     "weight": 0.9,
     "flavor": "観測者が変わっても変わらぬ核、誠実の興味の粒子。砕けても破片にもまだ宿る。",
-    "flavor_en": "A particle of sincere interest, a core unaltered though the observer changes. Even shattered, it still dwells within the fragments."
+    "flavor_en": "A particle of sincere curiosity, a core unaltered though the observer changes. Even shattered, it still dwells within the fragments."
   },
   {
     "name": "嘘",
@@ -117,7 +117,7 @@
     "english": "lie",
     "weight": 1.0,
     "flavor": "本当と嘘の境界で揺れる、影の興味を宿す粒子。物語を駆動する燃料にもなれる。",
-    "flavor_en": "A particle bearing the interest of shadow, wavering at the boundary between truth and falsehood. It can also serve as fuel that drives a narrative."
+    "flavor_en": "A particle bearing the curiosity of shadow, wavering at the boundary between truth and falsehood. It can also serve as fuel that drives a narrative."
   },
   {
     "name": "運命",
@@ -125,7 +125,7 @@
     "english": "fate",
     "weight": 0.5,
     "flavor": "選択と偶然の網目が描く模様、巨視の興味の粒子。後から振り返ると形が見えてくる。",
-    "flavor_en": "A particle of macroscopic interest, a pattern woven by the lattice of choice and chance. Its form becomes visible only when looked back upon."
+    "flavor_en": "A particle of macroscopic curiosity, a pattern woven by the lattice of choice and chance. Its form becomes visible only when looked back upon."
   },
   {
     "name": "奇跡",
@@ -133,7 +133,7 @@
     "english": "miracle",
     "weight": 0.3,
     "flavor": "確率が屈する瞬間に立ち会う、稀少な興味の粒子。日常の中にも紛れ込む小さな歓喜。",
-    "flavor_en": "A rare particle of interest, witnessing the moment when probability yields. A small rejoicing that slips even into everyday life."
+    "flavor_en": "A rare particle of curiosity, witnessing the moment when probability yields. A small rejoicing that slips even into everyday life."
   },
   {
     "name": "栄光",
@@ -141,7 +141,7 @@
     "english": "glory",
     "weight": 0.7,
     "flavor": "結果が他者の眼差しを通して輝く、社会的興味の粒子。一瞬の光は影とともに長く残る。",
-    "flavor_en": "A particle of social interest, where outcome shines through the gaze of others. A momentary light lingers long, accompanied by its shadow."
+    "flavor_en": "A particle of social curiosity, where outcome shines through the gaze of others. A momentary light lingers long, accompanied by its shadow."
   },
   {
     "name": "屈辱",
@@ -149,7 +149,7 @@
     "english": "humiliation",
     "weight": 0.8,
     "flavor": "誇りが踏みにじられた跡に残る、痛みの興味を宿す粒子。再起の燃料になることもある。",
-    "flavor_en": "A particle bearing the interest of pain, remaining where pride has been trampled. It may also become the fuel for resurgence."
+    "flavor_en": "A particle bearing the curiosity of pain, remaining where pride has been trampled. It may also become the fuel for resurgence."
   },
   {
     "name": "喜び",
@@ -157,7 +157,7 @@
     "english": "joy",
     "weight": 1.0,
     "flavor": "心拍と表情が同時に弾む、純粋な興味の粒子。分けるほどに総量が増す不思議な熱。",
-    "flavor_en": "A pure particle of interest, where pulse and expression leap in unison. A curious warmth whose sum increases the more it is shared."
+    "flavor_en": "A pure particle of curiosity, where pulse and expression leap in unison. A curious warmth whose sum increases the more it is shared."
   },
   {
     "name": "悲しみ",
@@ -165,7 +165,7 @@
     "english": "sadness",
     "weight": 1.0,
     "flavor": "失った形の輪郭を撫でる、慰めの興味を宿す粒子。涙によって心が再構成されていく。",
-    "flavor_en": "A particle bearing the interest of solace, tracing the outline of what was lost. Through tears, the heart is gradually reconstituted."
+    "flavor_en": "A particle bearing the curiosity of solace, tracing the outline of what was lost. Through tears, the heart is gradually reconstituted."
   },
   {
     "name": "怒り",
@@ -173,7 +173,7 @@
     "english": "anger",
     "weight": 1.0,
     "flavor": "境界線が破られた合図、防衛の興味を宿す粒子。鎮める術を持つ者にこそ宿る力。",
-    "flavor_en": "A particle bearing the interest of defense, the signal that a boundary has been breached. A power that dwells only in those who possess the art to quell it."
+    "flavor_en": "A particle bearing the curiosity of defense, the signal that a boundary has been breached. A power that dwells only in those who possess the art to quell it."
   },
   {
     "name": "恐怖",
@@ -181,7 +181,7 @@
     "english": "fear",
     "weight": 1.0,
     "flavor": "未知に対する身体の先回り、警戒の興味を宿す粒子。理解できれば力に変換できる。",
-    "flavor_en": "A particle bearing the interest of vigilance, the body's foreshadowing of the unknown. Once understood, it can be converted into power."
+    "flavor_en": "A particle bearing the curiosity of vigilance, the body's foreshadowing of the unknown. Once understood, it can be converted into power."
   },
   {
     "name": "安心",
@@ -189,7 +189,7 @@
     "english": "relief",
     "weight": 1.0,
     "flavor": "緊張が解けた身体に流れ込む、ぬるい興味の粒子。深い呼吸が出来ることが証となる。",
-    "flavor_en": "A lukewarm particle of interest, flowing into the body once tension dissolves. A deep breath becomes its proof."
+    "flavor_en": "A lukewarm particle of curiosity, flowing into the body once tension dissolves. A deep breath becomes its proof."
   },
   {
     "name": "孤独",
@@ -197,7 +197,7 @@
     "english": "loneliness",
     "weight": 0.9,
     "flavor": "他者がいない時間に自分と出会う、内省の興味の粒子。深さは他者と分かち合う器を作る。",
-    "flavor_en": "A particle of introspective interest, meeting oneself in the absence of others. Its depth shapes the vessel that will be shared with others."
+    "flavor_en": "A particle of introspective curiosity, meeting oneself in the absence of others. Its depth shapes the vessel that will be shared with others."
   },
   {
     "name": "友情",
@@ -205,7 +205,7 @@
     "english": "friendship",
     "weight": 1.0,
     "flavor": "対等な眼差しを交わし合う、共鳴の興味を宿す粒子。沈黙さえ言葉として通じ合う関係。",
-    "flavor_en": "A particle bearing the interest of resonance, exchanging gazes of equal standing. A bond in which even silence is understood as language."
+    "flavor_en": "A particle bearing the curiosity of resonance, exchanging gazes of equal standing. A bond in which even silence is understood as language."
   },
   {
     "name": "信頼",
@@ -213,7 +213,7 @@
     "english": "trust",
     "weight": 1.0,
     "flavor": "未来を相手に預ける、緩やかで強い興味の粒子。築くのは年月、壊すのは一瞬となる。",
-    "flavor_en": "A gentle yet potent particle of interest, entrusting the future to another. Years to build, an instant to shatter."
+    "flavor_en": "A gentle yet potent particle of curiosity, entrusting the future to another. Years to build, an instant to shatter."
   },
   {
     "name": "裏切り",
@@ -221,7 +221,7 @@
     "english": "betrayal",
     "weight": 0.7,
     "flavor": "築かれた信頼に走る亀裂、痛烈な興味の粒子。傷の形が世界の輪郭を再定義する。",
-    "flavor_en": "A piercing particle of interest, a fissure running through trust once built. The shape of the wound redefines the outline of the world."
+    "flavor_en": "A piercing particle of curiosity, a fissure running through trust once built. The shape of the wound redefines the outline of the world."
   },
   {
     "name": "魂",
@@ -229,7 +229,7 @@
     "english": "soul",
     "weight": 0.6,
     "flavor": "肉体を脱いでも残るかもしれない、形なき興味の粒子。観測できないが確かに在るもの。",
-    "flavor_en": "A formless particle of interest, that may yet remain when the flesh is shed. Something that cannot be observed, yet assuredly exists."
+    "flavor_en": "A formless particle of curiosity, that may yet remain when the flesh is shed. Something that cannot be observed, yet assuredly exists."
   },
   {
     "name": "精神",
@@ -237,7 +237,7 @@
     "english": "spirit",
     "weight": 0.8,
     "flavor": "肉体を統べる司令塔、意識の興味を宿す粒子。鍛えれば現実をも書き換える力となる。",
-    "flavor_en": "A particle bearing the interest of consciousness, the command tower that governs the body. Tempered, it becomes a force that can rewrite reality itself."
+    "flavor_en": "A particle bearing the curiosity of consciousness, the command tower that governs the body. Tempered, it becomes a force that can rewrite reality itself."
   },
   {
     "name": "意志",
@@ -245,7 +245,7 @@
     "english": "will",
     "weight": 0.9,
     "flavor": "未来を現在へ手繰り寄せる、推進の興味の粒子。折れない強さよりしなる強さが本質。",
-    "flavor_en": "A particle of propulsive interest, drawing the future toward the present. Its essence lies not in unbreakable strength but in supple resilience."
+    "flavor_en": "A particle of propulsive curiosity, drawing the future toward the present. Its essence lies not in unbreakable strength but in supple resilience."
   },
   {
     "name": "欲望",
@@ -253,7 +253,7 @@
     "english": "desire",
     "weight": 0.8,
     "flavor": "存在を駆動する燃料、原動の興味を宿す粒子。手綱を握れば翼となり離せば荒馬となる。",
-    "flavor_en": "A particle bearing the interest of primal drive, the fuel that propels existence. Held by the reins it becomes wings; released, a wild horse."
+    "flavor_en": "A particle bearing the curiosity of primal drive, the fuel that propels existence. Held by the reins it becomes wings; released, a wild horse."
   },
   {
     "name": "理性",
@@ -261,7 +261,7 @@
     "english": "reason",
     "weight": 0.8,
     "flavor": "感情の波を観測する灯台、観測の興味を宿す粒子。冷たさではなく明晰さが本質となる。",
-    "flavor_en": "A particle bearing the interest of observation, a lighthouse observing the waves of emotion. Its essence is not coldness but clarity."
+    "flavor_en": "A particle bearing the curiosity of observation, a lighthouse observing the waves of emotion. Its essence is not coldness but clarity."
   },
   {
     "name": "本能",
@@ -269,7 +269,7 @@
     "english": "instinct",
     "weight": 0.9,
     "flavor": "言葉以前から身体に住む、古層の興味を宿す粒子。理屈を越えて命の判断を下してくる。",
-    "flavor_en": "A particle bearing the interest of ancient strata, dwelling in the body since before language. It renders the judgment of life beyond all logic."
+    "flavor_en": "A particle bearing the curiosity of ancient strata, dwelling in the body since before language. It renders the judgment of life beyond all logic."
   },
   {
     "name": "永遠",
@@ -277,7 +277,7 @@
     "english": "eternity",
     "weight": 0.4,
     "flavor": "終わりを持たぬ広がり、無限の興味を宿す粒子。一瞬の中にも畳まれて宿ることがある。",
-    "flavor_en": "A particle bearing the interest of the infinite, an expanse possessing no end. It may at times be folded and contained within a single instant."
+    "flavor_en": "A particle bearing the curiosity of the infinite, an expanse possessing no end. It may at times be folded and contained within a single instant."
   },
   {
     "name": "刹那",
@@ -285,7 +285,7 @@
     "english": "moment",
     "weight": 0.7,
     "flavor": "切り取れぬほど短い時間の名、稀少な興味の粒子。集中の中でだけ可視化される時間。",
-    "flavor_en": "A rare particle of interest, the name for a span of time too brief to be excised. A duration made visible only within concentration."
+    "flavor_en": "A rare particle of curiosity, the name for a span of time too brief to be excised. A duration made visible only within concentration."
   },
   {
     "name": "無限",
@@ -293,7 +293,7 @@
     "english": "infinity",
     "weight": 0.3,
     "flavor": "終わりが定義されないことの自由、開放の興味の粒子。数字を超えた概念の海となる。",
-    "flavor_en": "A particle of liberating interest, the freedom of having no defined end. It becomes a conceptual ocean that transcends mere number."
+    "flavor_en": "A particle of liberating curiosity, the freedom of having no defined end. It becomes a conceptual ocean that transcends mere number."
   },
   {
     "name": "虚無",
@@ -301,7 +301,7 @@
     "english": "nothingness",
     "weight": 0.2,
     "flavor": "全てが消えた後に立つ広がり、静寂の興味の粒子。無こそ最大の容器だと囁いてくる。",
-    "flavor_en": "A particle of silent interest, the expanse that stands once all has vanished. It whispers that nothingness itself is the greatest vessel."
+    "flavor_en": "A particle of silent curiosity, the expanse that stands once all has vanished. It whispers that nothingness itself is the greatest vessel."
   },
   {
     "name": "存在",
@@ -309,7 +309,7 @@
     "english": "existence",
     "weight": 0.6,
     "flavor": "「在る」という最も基本的な事実、根源の興味の粒子。ここに在ること自体が奇跡。",
-    "flavor_en": "A particle of foundational interest, the most basic fact of \"being.\" To be here at all is itself a miracle."
+    "flavor_en": "A particle of foundational curiosity, the most basic fact of \"being.\" To be here at all is itself a miracle."
   },
   {
     "name": "創造",
@@ -317,7 +317,7 @@
     "english": "creation",
     "weight": 0.5,
     "flavor": "無から有を立ち上げる、火花のような興味の粒子。観測者を作り手に変える瞬間の輝き。",
-    "flavor_en": "A spark-like particle of interest, raising being from nonbeing. The radiance of the moment that transforms the observer into the maker."
+    "flavor_en": "A spark-like particle of curiosity, raising being from nonbeing. The radiance of the moment that transforms the observer into the maker."
   },
   {
     "name": "破壊",
@@ -325,7 +325,7 @@
     "english": "destruction",
     "weight": 0.6,
     "flavor": "形を解いて素材へ戻す、解体の興味を宿す粒子。次の創造のための余白を空けていく。",
-    "flavor_en": "A particle bearing the interest of dismantling, dissolving form back into material. It clears the blank space for the next creation."
+    "flavor_en": "A particle bearing the curiosity of dismantling, dissolving form back into material. It clears the blank space for the next creation."
   },
   {
     "name": "生命",
@@ -333,7 +333,7 @@
     "english": "life",
     "weight": 0.7,
     "flavor": "情報が温度を持って動き続ける、奇跡の興味の粒子。一秒の継続が宇宙最大の事件となる。",
-    "flavor_en": "A miraculous particle of interest, information continuing to move with warmth. Its continuance for a single second is the universe's greatest event."
+    "flavor_en": "A miraculous particle of curiosity, information continuing to move with warmth. Its continuance for a single second is the universe's greatest event."
   },
   {
     "name": "死",
@@ -341,7 +341,7 @@
     "english": "death",
     "weight": 0.5,
     "flavor": "形ある全てに必ず約束された、境界の興味の粒子。怖れる対象であり指針でもある。",
-    "flavor_en": "A particle of liminal interest, promised without fail to all that holds form. An object of dread, yet also a guiding compass."
+    "flavor_en": "A particle of liminal curiosity, promised without fail to all that holds form. An object of dread, yet also a guiding compass."
   },
   {
     "name": "再生",
@@ -349,7 +349,7 @@
     "english": "rebirth",
     "weight": 0.4,
     "flavor": "終わったはずの形が再び芽吹く、循環の興味を宿す粒子。死を栄養に変える生命の知恵。",
-    "flavor_en": "A particle bearing the interest of cycles, where a form supposedly ended buds forth once more. The wisdom of life that transmutes death into nourishment."
+    "flavor_en": "A particle bearing the curiosity of cycles, where a form supposedly ended buds forth once more. The wisdom of life that transmutes death into nourishment."
   },
   {
     "name": "記憶",
@@ -357,7 +357,7 @@
     "english": "memory",
     "weight": 0.9,
     "flavor": "過去を未来へ運ぶ薄膜、橋渡しの興味を宿す粒子。歪みながらも自分の輪郭を保つ礎。",
-    "flavor_en": "A particle bearing the interest of mediation, a thin membrane that conveys the past into the future. The foundation that preserves one's outline even as it warps."
+    "flavor_en": "A particle bearing the curiosity of mediation, a thin membrane that conveys the past into the future. The foundation that preserves one's outline even as it warps."
   },
   {
     "name": "忘却",
@@ -365,7 +365,7 @@
     "english": "oblivion",
     "weight": 0.6,
     "flavor": "心を軽くする慈悲、空白の興味を宿す粒子。覚え続けるためには手放しもまた必要。",
-    "flavor_en": "A particle bearing the interest of blankness, a mercy that lightens the heart. To continue remembering, one must also learn to release."
+    "flavor_en": "A particle bearing the curiosity of blankness, a mercy that lightens the heart. To continue remembering, one must also learn to release."
   },
   {
     "name": "時",
@@ -373,7 +373,7 @@
     "english": "time",
     "weight": 0.5,
     "flavor": "戻れない方向に流れる、不可逆の興味の粒子。観測することで形を変えてしまう存在。",
-    "flavor_en": "A particle of irreversible interest, flowing in a direction from which there is no return. An existence whose very form alters by being observed."
+    "flavor_en": "A particle of irreversible curiosity, flowing in a direction from which there is no return. An existence whose very form alters by being observed."
   },
   {
     "name": "空",
@@ -381,7 +381,7 @@
     "english": "void",
     "weight": 0.4,
     "flavor": "全てが在りつつ全てが空である、逆説の興味の粒子。容れ物としての宇宙の名でもある。",
-    "flavor_en": "A particle of paradoxical interest, where all exists and all is empty. It is also a name for the universe as a vessel."
+    "flavor_en": "A particle of paradoxical curiosity, where all exists and all is empty. It is also a name for the universe as a vessel."
   },
   {
     "name": "因果",
@@ -389,7 +389,7 @@
     "english": "causality",
     "weight": 0.3,
     "flavor": "原因と結果を結ぶ見えない糸、連鎖の興味の粒子。種を蒔く手の責任を静かに示す。",
-    "flavor_en": "A particle of linked interest, the invisible thread binding cause to effect. It quietly intimates the responsibility of the hand that sows the seed."
+    "flavor_en": "A particle of linked curiosity, the invisible thread binding cause to effect. It quietly intimates the responsibility of the hand that sows the seed."
   },
   {
     "name": "輪廻",
@@ -397,7 +397,7 @@
     "english": "samsara",
     "weight": 0.2,
     "flavor": "終わらず巡り続ける円環、回帰の興味を宿す粒子。今日の行いが遥か先で実を結ぶ。",
-    "flavor_en": "A particle bearing the interest of recurrence, an unending ring that revolves on. Today's deed bears fruit in the distant beyond."
+    "flavor_en": "A particle bearing the curiosity of recurrence, an unending ring that revolves on. Today's deed bears fruit in the distant beyond."
   },
   {
     "name": "時間",
@@ -405,7 +405,7 @@
     "english": "time",
     "weight": 0.5,
     "flavor": "万物を運ぶ目に見えぬ川、不可逆の興味を宿す粒子。観測する者だけが感じ取れる流れ。",
-    "flavor_en": "A particle bearing the interest of irreversibility, an unseen river that conveys all things. A current perceptible only to the one who observes."
+    "flavor_en": "A particle bearing the curiosity of irreversibility, an unseen river that conveys all things. A current perceptible only to the one who observes."
   },
   {
     "name": "空間",
@@ -413,6 +413,6 @@
     "english": "space",
     "weight": 0.5,
     "flavor": "存在が広がる土台、容器の興味を宿す粒子。曲がり伸び縮みする現代の柔らかな概念。",
-    "flavor_en": "A particle bearing the interest of containment, the foundation upon which existence extends. A modern, supple concept that bends, stretches, and contracts."
+    "flavor_en": "A particle bearing the curiosity of containment, the foundation upon which existence extends. A modern, supple concept that bends, stretches, and contracts."
   }
 ]

--- a/data/nouns/animals.json
+++ b/data/nouns/animals.json
@@ -13,7 +13,7 @@
     "english": "cat",
     "weight": 1.0,
     "flavor": "気まぐれな興味の化身。観測者の視線を、独立した軌道で躱す不思議な粒子。",
-    "flavor_en": "An incarnation of capricious interest. A mysterious particle that dodges the observer's gaze on its own independent orbit."
+    "flavor_en": "An incarnation of capricious curiosity. A mysterious particle that dodges the observer's gaze on its own independent orbit."
   },
   {
     "name": "犬",
@@ -21,7 +21,7 @@
     "english": "dog",
     "weight": 1.0,
     "flavor": "忠実な興味を結晶化した粒子。離れていても主の心に共鳴し続ける。",
-    "flavor_en": "A particle that crystallizes faithful interest. Resonating with its master's heart even from afar."
+    "flavor_en": "A particle that crystallizes faithful curiosity. Resonating with its master's heart even from afar."
   },
   {
     "name": "鳥",
@@ -29,7 +29,7 @@
     "english": "bird",
     "weight": 1.0,
     "flavor": "自由を意味する興味の翼。空という未踏領域へ意識を運ぶ伝令の粒子。",
-    "flavor_en": "Wings of interest signifying freedom. A messenger particle that carries consciousness into the uncharted realm of the sky."
+    "flavor_en": "Wings of curiosity signifying freedom. A messenger particle that carries consciousness into the uncharted realm of the sky."
   },
   {
     "name": "龍",
@@ -45,7 +45,7 @@
     "english": "whale",
     "weight": 0.5,
     "flavor": "海の底に眠る、巨大で穏やかな興味の粒子。深い知性の歌を響かせる。",
-    "flavor_en": "A vast and gentle particle of interest slumbering in ocean depths. Resounding with the song of profound intelligence."
+    "flavor_en": "A vast and gentle particle of curiosity slumbering in ocean depths. Resounding with the song of profound intelligence."
   },
   {
     "name": "蝶",
@@ -61,7 +61,7 @@
     "english": "spider",
     "weight": 1.0,
     "flavor": "見えない網で世界を編む、忍耐の興味を宿した粒子。観測の達人。",
-    "flavor_en": "A particle harboring patient interest, weaving the world with an invisible web. A master of observation."
+    "flavor_en": "A particle harboring patient curiosity, weaving the world with an invisible web. A master of observation."
   },
   {
     "name": "狼",
@@ -69,7 +69,7 @@
     "english": "wolf",
     "weight": 0.7,
     "flavor": "群れと孤独の両方を背負う、誇り高き興味の粒子。月夜に冴える鋭い精神。",
-    "flavor_en": "A proud particle of interest bearing both pack and solitude. A keen spirit sharpened beneath the moonlit night."
+    "flavor_en": "A proud particle of curiosity bearing both pack and solitude. A keen spirit sharpened beneath the moonlit night."
   },
   {
     "name": "熊",
@@ -77,7 +77,7 @@
     "english": "bear",
     "weight": 0.8,
     "flavor": "ゆったりと深い興味を抱える、森の長老のような粒子。冬を越えてなお目覚める。",
-    "flavor_en": "A particle harboring leisurely, profound interest, like an elder of the forest. Awakening still after enduring winter."
+    "flavor_en": "A particle harboring leisurely, profound curiosity, like an elder of the forest. Awakening still after enduring winter."
   },
   {
     "name": "兎",
@@ -85,7 +85,7 @@
     "english": "rabbit",
     "weight": 1.0,
     "flavor": "跳ねるように湧き上がる、軽やかな興味の粒子。月の影を駆ける夢の住人。",
-    "flavor_en": "A nimble particle of interest that springs up in leaps. A dweller of dreams that races across the lunar shadow."
+    "flavor_en": "A nimble particle of curiosity that springs up in leaps. A dweller of dreams that races across the lunar shadow."
   },
   {
     "name": "鹿",
@@ -93,7 +93,7 @@
     "english": "deer",
     "weight": 0.9,
     "flavor": "静謐な森に生まれる、繊細で気品ある興味の粒子。視線が交わるだけで心が澄む。",
-    "flavor_en": "A delicate, dignified particle of interest born in tranquil forests. The mere meeting of gazes brings clarity to the heart."
+    "flavor_en": "A delicate, dignified particle of curiosity born in tranquil forests. The mere meeting of gazes brings clarity to the heart."
   },
   {
     "name": "虎",
@@ -101,7 +101,7 @@
     "english": "tiger",
     "weight": 0.5,
     "flavor": "燃え盛る縞模様の、獰猛な興味を宿す粒子。一閃の集中が世界を切り裂く。",
-    "flavor_en": "A particle harboring ferocious interest in blazing stripes. A single flash of focus cleaves through the world."
+    "flavor_en": "A particle harboring ferocious curiosity in blazing stripes. A single flash of focus cleaves through the world."
   },
   {
     "name": "象",
@@ -109,7 +109,7 @@
     "english": "elephant",
     "weight": 0.6,
     "flavor": "巨大な記憶と緩やかな興味を運ぶ、大地に近しい粒子。決して忘れない瞳を持つ。",
-    "flavor_en": "A particle close to the earth, carrying vast memory and gentle interest. Bearing eyes that never forget."
+    "flavor_en": "A particle close to the earth, carrying vast memory and gentle curiosity. Bearing eyes that never forget."
   },
   {
     "name": "猿",
@@ -117,7 +117,7 @@
     "english": "monkey",
     "weight": 1.0,
     "flavor": "好奇心そのものを擬人化したような、跳躍的な興味の粒子。世界に手を伸ばし続ける。",
-    "flavor_en": "A leaping particle of interest, as though curiosity itself were personified. Forever reaching out toward the world."
+    "flavor_en": "A leaping particle of curiosity, as though curiosity itself were personified. Forever reaching out toward the world."
   },
   {
     "name": "馬",
@@ -125,7 +125,7 @@
     "english": "horse",
     "weight": 1.0,
     "flavor": "風と並走する、疾駆する興味の粒子。蹄の音が新たな地平を切り開いていく。",
-    "flavor_en": "A galloping particle of interest, running alongside the wind. The sound of hooves opens new horizons."
+    "flavor_en": "A galloping particle of curiosity, running alongside the wind. The sound of hooves opens new horizons."
   },
   {
     "name": "蛇",
@@ -133,7 +133,7 @@
     "english": "snake",
     "weight": 1.0,
     "flavor": "脱皮を繰り返す、再生の興味を司る粒子。冷たく賢く、地を這って真理に近づく。",
-    "flavor_en": "A particle presiding over the interest of rebirth, shedding skin again and again. Cold and wise, crawling along the earth toward truth."
+    "flavor_en": "A particle presiding over the curiosity of rebirth, shedding skin again and again. Cold and wise, crawling along the earth toward truth."
   },
   {
     "name": "亀",
@@ -141,7 +141,7 @@
     "english": "turtle",
     "weight": 1.0,
     "flavor": "悠久の時間に寄り添う、辛抱強い興味の粒子。甲羅に星の数だけの記憶を刻む。",
-    "flavor_en": "A patient particle of interest that abides with eternal time. Engraving as many memories as there are stars upon its shell."
+    "flavor_en": "A patient particle of curiosity that abides with eternal time. Engraving as many memories as there are stars upon its shell."
   },
   {
     "name": "蛙",
@@ -149,7 +149,7 @@
     "english": "frog",
     "weight": 1.0,
     "flavor": "水と陸の境界に佇む、変態を象徴する興味の粒子。雨が降ると心が躍る。",
-    "flavor_en": "A particle of interest standing at the boundary of water and land, symbolizing metamorphosis. When the rain falls, its heart dances."
+    "flavor_en": "A particle of curiosity standing at the boundary of water and land, symbolizing metamorphosis. When the rain falls, its heart dances."
   },
   {
     "name": "鷲",
@@ -157,7 +157,7 @@
     "english": "eagle",
     "weight": 0.6,
     "flavor": "高所から世界を俯瞰する、鋭利な興味の粒子。視野の広さが見識を磨いていく。",
-    "flavor_en": "A keen particle of interest that surveys the world from on high. The breadth of its vision hones its insight."
+    "flavor_en": "A keen particle of curiosity that surveys the world from on high. The breadth of its vision hones its insight."
   },
   {
     "name": "鶴",
@@ -165,7 +165,7 @@
     "english": "crane",
     "weight": 0.7,
     "flavor": "千年を生きるとされる、優雅さを宿した興味の粒子。羽ばたきが祝祭を運んでくる。",
-    "flavor_en": "A particle of interest harboring elegance, said to live a thousand years. Its wingbeats bring forth celebration."
+    "flavor_en": "A particle of curiosity harboring elegance, said to live a thousand years. Its wingbeats bring forth celebration."
   },
   {
     "name": "狐",
@@ -173,7 +173,7 @@
     "english": "fox",
     "weight": 0.9,
     "flavor": "知恵と幻惑を兼ね備えた、悪戯好きな興味の粒子。真贋を見抜く瞳を持っている。",
-    "flavor_en": "A mischievous particle of interest possessing both wisdom and illusion. Bearing eyes that discern the true from the false."
+    "flavor_en": "A mischievous particle of curiosity possessing both wisdom and illusion. Bearing eyes that discern the true from the false."
   },
   {
     "name": "狸",
@@ -181,7 +181,7 @@
     "english": "raccoon dog",
     "weight": 1.0,
     "flavor": "化けることで真実を語る、ユーモラスな興味の粒子。腹鼓で世界の堅さを和らげる。",
-    "flavor_en": "A humorous particle of interest that speaks truth through transformation. Its belly-drum softens the rigidity of the world."
+    "flavor_en": "A humorous particle of curiosity that speaks truth through transformation. Its belly-drum softens the rigidity of the world."
   },
   {
     "name": "鼠",
@@ -189,7 +189,7 @@
     "english": "mouse",
     "weight": 1.0,
     "flavor": "暗がりにこそ宿る、機敏な興味の粒子。隅々を駆け抜けては小さな発見を持ち帰る。",
-    "flavor_en": "A nimble particle of interest that dwells precisely in the shadows. Racing through every corner, returning with small discoveries."
+    "flavor_en": "A nimble particle of curiosity that dwells precisely in the shadows. Racing through every corner, returning with small discoveries."
   },
   {
     "name": "蝙蝠",
@@ -197,7 +197,7 @@
     "english": "bat",
     "weight": 0.8,
     "flavor": "光ではなく音で世界を識る、逆説的な興味の粒子。闇に響く声が地図を描く。",
-    "flavor_en": "A paradoxical particle of interest that perceives the world through sound rather than light. Voices echoing in darkness sketch the map."
+    "flavor_en": "A paradoxical particle of curiosity that perceives the world through sound rather than light. Voices echoing in darkness sketch the map."
   },
   {
     "name": "蝸牛",
@@ -205,7 +205,7 @@
     "english": "snail",
     "weight": 1.0,
     "flavor": "螺旋を背負い、緩慢に進む静かな興味の粒子。急がぬことこそ深さだと示してくれる。",
-    "flavor_en": "A quiet particle of interest advancing slowly, bearing a spiral upon its back. It shows us that depth lies in not hastening."
+    "flavor_en": "A quiet particle of curiosity advancing slowly, bearing a spiral upon its back. It shows us that depth lies in not hastening."
   },
   {
     "name": "蟻",
@@ -213,7 +213,7 @@
     "english": "ant",
     "weight": 1.0,
     "flavor": "群体として知性を発揮する、勤勉な興味の粒子。一粒一粒が巨大な意志を形作る。",
-    "flavor_en": "A diligent particle of interest that manifests intelligence as a colony. Each single grain forms a vast collective will."
+    "flavor_en": "A diligent particle of curiosity that manifests intelligence as a colony. Each single grain forms a vast collective will."
   },
   {
     "name": "蜂",
@@ -221,7 +221,7 @@
     "english": "bee",
     "weight": 1.0,
     "flavor": "甘さの探究者にして、規律ある興味の粒子。六角形の宇宙に未来を蓄えていく。",
-    "flavor_en": "A seeker of sweetness and a disciplined particle of interest. Storing the future within a hexagonal cosmos."
+    "flavor_en": "A seeker of sweetness and a disciplined particle of curiosity. Storing the future within a hexagonal cosmos."
   },
   {
     "name": "蚊",
@@ -229,7 +229,7 @@
     "english": "mosquito",
     "weight": 1.0,
     "flavor": "些細だが鋭利な、執拗な興味の粒子。夜の静けさを破り、生の血脈を意識させる。",
-    "flavor_en": "A trivial yet sharp, persistent particle of interest. Breaking the silence of night, making one conscious of the pulse of life."
+    "flavor_en": "A trivial yet sharp, persistent particle of curiosity. Breaking the silence of night, making one conscious of the pulse of life."
   },
   {
     "name": "鳳凰",
@@ -261,7 +261,7 @@
     "english": "shark",
     "weight": 0.6,
     "flavor": "止まれば沈む宿命を背負う、前進の興味を持つ粒子。鋭い嗅覚が真実を嗅ぎ分ける。",
-    "flavor_en": "A particle of forward-moving interest bearing the fate of sinking if it halts. Its sharp sense discerns the scent of truth."
+    "flavor_en": "A particle of forward-moving curiosity bearing the fate of sinking if it halts. Its sharp sense discerns the scent of truth."
   },
   {
     "name": "海豚",
@@ -269,7 +269,7 @@
     "english": "dolphin",
     "weight": 0.7,
     "flavor": "海中で歌い合う、社交的で知性に満ちた興味の粒子。波間に笑い声が響く。",
-    "flavor_en": "A sociable particle of interest filled with intelligence, singing to one another beneath the waves. Laughter resounds between the swells."
+    "flavor_en": "A sociable particle of curiosity filled with intelligence, singing to one another beneath the waves. Laughter resounds between the swells."
   },
   {
     "name": "章魚",
@@ -285,7 +285,7 @@
     "english": "squid",
     "weight": 0.8,
     "flavor": "墨で輪郭を消す、戦略的な興味を宿す粒子。深海の暗闇に思考を漂わせる。",
-    "flavor_en": "A particle harboring strategic interest, erasing its outline with ink. Letting its thoughts drift through the darkness of the deep sea."
+    "flavor_en": "A particle harboring strategic curiosity, erasing its outline with ink. Letting its thoughts drift through the darkness of the deep sea."
   },
   {
     "name": "海月",
@@ -293,7 +293,7 @@
     "english": "jellyfish",
     "weight": 1.0,
     "flavor": "形を持たぬまま漂う、透明な興味の粒子。生死の境すらやわらかく溶かしてしまう。",
-    "flavor_en": "A transparent particle of interest, drifting without form. Even the boundary between life and death is softly dissolved."
+    "flavor_en": "A transparent particle of curiosity, drifting without form. Even the boundary between life and death is softly dissolved."
   },
   {
     "name": "海星",
@@ -301,7 +301,7 @@
     "english": "starfish",
     "weight": 1.0,
     "flavor": "五芒の腕で海底を歩む、星座のような興味の粒子。ゆっくりと再生する忍耐の輝き。",
-    "flavor_en": "A constellation-like particle of interest, walking the seabed with five-pointed arms. A patient radiance that slowly regenerates."
+    "flavor_en": "A constellation-like particle of curiosity, walking the seabed with five-pointed arms. A patient radiance that slowly regenerates."
   },
   {
     "name": "獅子",
@@ -309,7 +309,7 @@
     "english": "lion",
     "weight": 0.5,
     "flavor": "百獣の王として君臨する、誇り高き興味の粒子。咆哮ひとつで群衆の心を統べる。",
-    "flavor_en": "A proud particle of interest that reigns as king of all beasts. A single roar governs the hearts of the multitude."
+    "flavor_en": "A proud particle of curiosity that reigns as king of all beasts. A single roar governs the hearts of the multitude."
   },
   {
     "name": "豹",
@@ -317,7 +317,7 @@
     "english": "leopard",
     "weight": 0.6,
     "flavor": "音もなく忍び寄る、研ぎ澄まされた興味の粒子。斑模様に世界の影を宿す。",
-    "flavor_en": "A honed particle of interest that creeps near without sound. The shadows of the world reside within its spotted pattern."
+    "flavor_en": "A honed particle of curiosity that creeps near without sound. The shadows of the world reside within its spotted pattern."
   },
   {
     "name": "豚",
@@ -325,7 +325,7 @@
     "english": "pig",
     "weight": 1.0,
     "flavor": "豊かさと愛嬌を併せ持つ、丸みのある興味の粒子。賢さを愚かさで覆い隠す名手。",
-    "flavor_en": "A rounded particle of interest possessing both abundance and charm. A master at concealing wisdom beneath folly."
+    "flavor_en": "A rounded particle of curiosity possessing both abundance and charm. A master at concealing wisdom beneath folly."
   },
   {
     "name": "牛",
@@ -333,7 +333,7 @@
     "english": "cow",
     "weight": 1.0,
     "flavor": "大地を耕し続けてきた、忠実で力強い興味の粒子。咀嚼するように真理を反芻する。",
-    "flavor_en": "A faithful and powerful particle of interest that has long tilled the earth. Ruminating upon truth as though chewing."
+    "flavor_en": "A faithful and powerful particle of curiosity that has long tilled the earth. Ruminating upon truth as though chewing."
   },
   {
     "name": "羊",
@@ -341,7 +341,7 @@
     "english": "sheep",
     "weight": 1.0,
     "flavor": "群れに寄り添う、柔らかな興味の粒子。眠りの数を数えるたび世界が静かになる。",
-    "flavor_en": "A soft particle of interest that nestles within the flock. With each count of sleep, the world grows still."
+    "flavor_en": "A soft particle of curiosity that nestles within the flock. With each count of sleep, the world grows still."
   },
   {
     "name": "山羊",
@@ -349,7 +349,7 @@
     "english": "goat",
     "weight": 1.0,
     "flavor": "崖を平然と歩む、孤高で気高い興味の粒子。瞳の横長い瞳孔は別世界を映す。",
-    "flavor_en": "A solitary and noble particle of interest that walks the cliffs with composure. Its horizontal pupils reflect another world."
+    "flavor_en": "A solitary and noble particle of curiosity that walks the cliffs with composure. Its horizontal pupils reflect another world."
   },
   {
     "name": "駱駝",
@@ -357,7 +357,7 @@
     "english": "camel",
     "weight": 0.7,
     "flavor": "砂漠を渡る、忍耐そのもののような興味の粒子。背の瘤に未来の水を蓄えている。",
-    "flavor_en": "A particle of interest like patience itself, traversing the desert. Storing the water of the future within the hump upon its back."
+    "flavor_en": "A particle of curiosity like patience itself, traversing the desert. Storing the water of the future within the hump upon its back."
   },
   {
     "name": "河馬",
@@ -365,7 +365,7 @@
     "english": "hippopotamus",
     "weight": 0.6,
     "flavor": "水中に潜む、巨大で静かな興味の粒子。穏やかに見えて怒らせれば嵐を呼ぶ。",
-    "flavor_en": "A vast and silent particle of interest lurking beneath the water. Calm in appearance, yet summoning storms when angered."
+    "flavor_en": "A vast and silent particle of curiosity lurking beneath the water. Calm in appearance, yet summoning storms when angered."
   },
   {
     "name": "犀",
@@ -373,7 +373,7 @@
     "english": "rhinoceros",
     "weight": 0.5,
     "flavor": "一本角に伝説を宿す、寡黙な興味の粒子。突進すれば常識すら砕けてしまう。",
-    "flavor_en": "A taciturn particle of interest harboring legend within a single horn. When it charges, even common sense is shattered."
+    "flavor_en": "A taciturn particle of curiosity harboring legend within a single horn. When it charges, even common sense is shattered."
   },
   {
     "name": "鳩",
@@ -381,7 +381,7 @@
     "english": "pigeon",
     "weight": 1.0,
     "flavor": "平和の象徴として宙を舞う、慎ましい興味の粒子。手紙を運び、距離を縮めていく。",
-    "flavor_en": "A modest particle of interest that dances through the air as a symbol of peace. Bearing letters, drawing distances closer."
+    "flavor_en": "A modest particle of curiosity that dances through the air as a symbol of peace. Bearing letters, drawing distances closer."
   },
   {
     "name": "雀",
@@ -389,7 +389,7 @@
     "english": "sparrow",
     "weight": 1.0,
     "flavor": "身近に潜む、賑やかな興味の粒子。朝の空気を細やかなさえずりで彩り続ける。",
-    "flavor_en": "A lively particle of interest that lingers close at hand. Forever coloring the morning air with delicate chirping."
+    "flavor_en": "A lively particle of curiosity that lingers close at hand. Forever coloring the morning air with delicate chirping."
   },
   {
     "name": "鴉",
@@ -397,7 +397,7 @@
     "english": "crow",
     "weight": 1.0,
     "flavor": "賢さの黒衣をまとう、神秘的な興味の粒子。鏡を覗くように自分の姿を理解する。",
-    "flavor_en": "A mysterious particle of interest clad in the black robe of wisdom. Understanding its own form as though peering into a mirror."
+    "flavor_en": "A mysterious particle of curiosity clad in the black robe of wisdom. Understanding its own form as though peering into a mirror."
   },
   {
     "name": "燕",
@@ -405,7 +405,7 @@
     "english": "swallow",
     "weight": 1.0,
     "flavor": "春を運ぶ旅人として現れる、軽快な興味の粒子。軒先に幸福の予兆を巣作る。",
-    "flavor_en": "A nimble particle of interest that appears as a traveler bearing spring. Building nests of happy omens beneath the eaves."
+    "flavor_en": "A nimble particle of curiosity that appears as a traveler bearing spring. Building nests of happy omens beneath the eaves."
   },
   {
     "name": "鸚鵡",
@@ -413,7 +413,7 @@
     "english": "parrot",
     "weight": 0.7,
     "flavor": "言葉を映す、模倣の興味を司る粒子。誰の声でも自分のものに変えてしまう才。",
-    "flavor_en": "A particle presiding over the interest of mimicry, reflecting words. Possessing the talent to make any voice its own."
+    "flavor_en": "A particle presiding over the curiosity of mimicry, reflecting words. Possessing the talent to make any voice its own."
   },
   {
     "name": "梟",
@@ -421,7 +421,7 @@
     "english": "owl",
     "weight": 0.8,
     "flavor": "夜の知恵を司る、静謐な興味の粒子。首を巡らせて見えない世界を観測している。",
-    "flavor_en": "A tranquil particle of interest that presides over the wisdom of night. Turning its head to observe the unseen world."
+    "flavor_en": "A tranquil particle of curiosity that presides over the wisdom of night. Turning its head to observe the unseen world."
   },
   {
     "name": "孔雀",
@@ -429,7 +429,7 @@
     "english": "peacock",
     "weight": 0.4,
     "flavor": "扇のような飾りを広げる、誇示の興味を宿す粒子。美しさは生存の戦略だと教える。",
-    "flavor_en": "A particle harboring the interest of display, spreading its fan-like adornment. Teaching that beauty is a strategy of survival."
+    "flavor_en": "A particle harboring the curiosity of display, spreading its fan-like adornment. Teaching that beauty is a strategy of survival."
   },
   {
     "name": "鴨",
@@ -437,7 +437,7 @@
     "english": "duck",
     "weight": 1.0,
     "flavor": "水に浮かびつつ足は休まぬ、忍耐の興味を持つ粒子。表面の優雅さの裏に努力あり。",
-    "flavor_en": "A particle of patient interest whose feet never rest while it floats upon the water. Behind surface grace lies ceaseless effort."
+    "flavor_en": "A particle of patient curiosity whose feet never rest while it floats upon the water. Behind surface grace lies ceaseless effort."
   },
   {
     "name": "白鳥",
@@ -445,7 +445,7 @@
     "english": "swan",
     "weight": 0.6,
     "flavor": "湖面に映る純白の興味、変身の伝説を抱く粒子。醜さを美に変える物語の主人公。",
-    "flavor_en": "Pure white interest mirrored upon the lake, a particle embracing the legend of transformation. The protagonist of a tale that turns ugliness into beauty."
+    "flavor_en": "Pure white curiosity mirrored upon the lake, a particle embracing the legend of transformation. The protagonist of a tale that turns ugliness into beauty."
   },
   {
     "name": "蝉",
@@ -453,7 +453,7 @@
     "english": "cicada",
     "weight": 1.0,
     "flavor": "数年の地中生活を経て鳴く、短く濃密な興味の粒子。夏の終わりを告げる声。",
-    "flavor_en": "A brief yet dense particle of interest that cries after years beneath the earth. A voice heralding the end of summer."
+    "flavor_en": "A brief yet dense particle of curiosity that cries after years beneath the earth. A voice heralding the end of summer."
   },
   {
     "name": "蜻蛉",
@@ -461,7 +461,7 @@
     "english": "dragonfly",
     "weight": 1.0,
     "flavor": "停空飛行で時間を切り取る、繊細な興味の粒子。複眼が世界の無数の真実を映す。",
-    "flavor_en": "A delicate particle of interest that cuts out time through hovering flight. Compound eyes reflecting innumerable truths of the world."
+    "flavor_en": "A delicate particle of curiosity that cuts out time through hovering flight. Compound eyes reflecting innumerable truths of the world."
   },
   {
     "name": "螢",
@@ -469,7 +469,7 @@
     "english": "firefly",
     "weight": 0.7,
     "flavor": "短い夜にだけ灯る、儚くも鮮烈な興味の粒子。光は呼吸のように明滅していく。",
-    "flavor_en": "An ephemeral yet vivid particle of interest, kindled only in brief nights. Its light flickers like breathing."
+    "flavor_en": "An ephemeral yet vivid particle of curiosity, kindled only in brief nights. Its light flickers like breathing."
   },
   {
     "name": "蛾",
@@ -477,7 +477,7 @@
     "english": "moth",
     "weight": 1.0,
     "flavor": "光に焼かれることも厭わぬ、執着の興味を宿す粒子。夜の蝶として静かに舞う。",
-    "flavor_en": "A particle harboring the interest of attachment, unafraid even of being scorched by light. Dancing silently as a butterfly of night."
+    "flavor_en": "A particle harboring the curiosity of attachment, unafraid even of being scorched by light. Dancing silently as a butterfly of night."
   },
   {
     "name": "甲虫",
@@ -485,7 +485,7 @@
     "english": "beetle",
     "weight": 0.8,
     "flavor": "鎧をまとった、堅実で勇猛な興味の粒子。子どもの宝石箱の常連でもある。",
-    "flavor_en": "A steadfast and valiant particle of interest, clad in armor. Also a regular within the jewel boxes of children."
+    "flavor_en": "A steadfast and valiant particle of curiosity, clad in armor. Also a regular within the jewel boxes of children."
   },
   {
     "name": "蟷螂",
@@ -493,7 +493,7 @@
     "english": "mantis",
     "weight": 0.9,
     "flavor": "祈るような前肢を持つ、冷静な狩人の興味を宿す粒子。捕食すら儀式に変える。",
-    "flavor_en": "A particle harboring the interest of a composed hunter, bearing forelimbs that seem to pray. Transforming even predation into ritual."
+    "flavor_en": "A particle harboring the curiosity of a composed hunter, bearing forelimbs that seem to pray. Transforming even predation into ritual."
   },
   {
     "name": "蝗",
@@ -501,7 +501,7 @@
     "english": "grasshopper",
     "weight": 1.0,
     "flavor": "群れて空を覆う、爆発的な興味の粒子。豊穣と災厄の境界線上を跳び続ける。",
-    "flavor_en": "An explosive particle of interest that swarms and veils the sky. Forever leaping upon the boundary between abundance and calamity."
+    "flavor_en": "An explosive particle of curiosity that swarms and veils the sky. Forever leaping upon the boundary between abundance and calamity."
   },
   {
     "name": "蠍",
@@ -509,7 +509,7 @@
     "english": "scorpion",
     "weight": 0.6,
     "flavor": "尾に毒を秘めた、孤高で防衛的な興味の粒子。星座にもなり夜空を護っている。",
-    "flavor_en": "A solitary and defensive particle of interest, harboring venom in its tail. Becoming a constellation as well, guarding the night sky."
+    "flavor_en": "A solitary and defensive particle of curiosity, harboring venom in its tail. Becoming a constellation as well, guarding the night sky."
   },
   {
     "name": "蟹",
@@ -517,7 +517,7 @@
     "english": "crab",
     "weight": 1.0,
     "flavor": "横歩きで世界に挑む、頑なな興味の粒子。鋏は守りであり挨拶でもある。",
-    "flavor_en": "A stubborn particle of interest that confronts the world with a sideways gait. Its claws are both defense and greeting."
+    "flavor_en": "A stubborn particle of curiosity that confronts the world with a sideways gait. Its claws are both defense and greeting."
   },
   {
     "name": "海老",
@@ -525,6 +525,6 @@
     "english": "shrimp",
     "weight": 1.0,
     "flavor": "古から保たれた姿で深海を生きる、長寿の興味を宿す粒子。脱皮で若返り続ける。",
-    "flavor_en": "A particle harboring the interest of longevity, dwelling in the deep sea in a form preserved since antiquity. Renewing its youth through molting."
+    "flavor_en": "A particle harboring the curiosity of longevity, dwelling in the deep sea in a form preserved since antiquity. Renewing its youth through molting."
   }
 ]

--- a/data/nouns/foods.json
+++ b/data/nouns/foods.json
@@ -13,7 +13,7 @@
     "english": "wheat",
     "weight": 1.0,
     "flavor": "風になびく金色の海、豊穣の興味を宿す粒子。挽かれてなお誰かの朝を温める。",
-    "flavor_en": "A golden sea swaying in the wind, a particle harboring the interest of abundance. Even when ground to flour, it warms someone's morning."
+    "flavor_en": "A golden sea swaying in the wind, a particle harboring the curiosity of abundance. Even when ground to flour, it warms someone's morning."
   },
   {
     "name": "豆",
@@ -125,7 +125,7 @@
     "english": "soy sauce",
     "weight": 1.0,
     "flavor": "黒く薫る液体、調和の興味を宿す粒子。一滴で皿の世界を引き締めてくれる。",
-    "flavor_en": "A dark, fragrant liquid, a particle harboring the interest of harmony. A single drop tightens the entire world of the plate."
+    "flavor_en": "A dark, fragrant liquid, a particle harboring the curiosity of harmony. A single drop tightens the entire world of the plate."
   },
   {
     "name": "酒",

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -51,6 +51,8 @@ The noun database exposes `NounDatabase::flavor_for(noun_name, lang)` which retu
 
 Phase 3b also unified the `flavor_en` vocabulary: occurrences of `"interest"` used in the sense of "curiosity" were rewritten to `curiosity` across `abstracts.json` (52), `animals.json` (59), and `foods.json` (2) to align with the repository name `curion` (= curiosity). English idioms such as `point of interest` were left untouched, but none existed in the dataset.
 
+The JA `flavor` strings are intentionally left unchanged in this phase. JA narration uses both "興味" and "好奇" with stylistic intent (per-category tone, as established in Phase 2 of #65), and consolidating them would alter prose rhythm without a player-visible benefit. A separate follow-up may revisit JA wording if a future content audit identifies inconsistencies that hurt readability.
+
 ### Phase 4 (Issue #71): Content i18n
 
 In addition to noun `english` / `flavor_en`, the following game-content fields carry an `_en` variant and are accessed through `*_for(lang)` helpers so the TUI renders the active `Language` consistently:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -43,7 +43,13 @@ Noun data is stored in `data/nouns/*.json` (one file per category). Each entry h
 | `english` | yes | Canonical English label. Surfaced through `App::display_curion_name` when the language is `En`. |
 | `weight` | yes | Relative spawn weight inside the category. |
 | `flavor` | yes | Japanese flavor text (SF / philosophical short prose). |
-| `flavor_en` | yes (since #65 Phase 2) | English flavor text. Phase 3 (Issue #68) will route flavor rendering through the language gate; until then the UI always displays `flavor`. |
+| `flavor_en` | yes (since #65 Phase 2) | English flavor text. Phase 3 (Issue #68) is complete: flavor rendering is now routed through the language gate via `NounDatabase::flavor_for(noun, lang)`. The helper falls back to JA `flavor` when `flavor_en` is empty or absent (same pattern as Phase 4). |
+
+### Phase 3 (Issue #68): Flavor i18n
+
+The noun database exposes `NounDatabase::flavor_for(noun_name, lang)` which returns the flavor for the requested language, falling back to JA when the EN entry is empty. All UI sites that render flavor (the Collection detail pane and the Dictionary entry list) thread `game_state.language` through this helper so `--lang en` no longer leaks JA flavor text. Synthesis-only nouns (`蒸気` / `残骸` etc.) still return `None` and let the caller render its own placeholder (`(フレーバー未登録)` / `(no flavor)`).
+
+Phase 3b also unified the `flavor_en` vocabulary: occurrences of `"interest"` used in the sense of "curiosity" were rewritten to `curiosity` across `abstracts.json` (52), `animals.json` (59), and `foods.json` (2) to align with the repository name `curion` (= curiosity). English idioms such as `point of interest` were left untouched, but none existed in the dataset.
 
 ### Phase 4 (Issue #71): Content i18n
 
@@ -505,7 +511,7 @@ Left pane sections:
   - 寿命なし (旧セーブ): `寿命: --`
 - Attribute bars (interest, beauty) shown inline
 - Bottom detail pane (`Constraint::Length(4)`, Issue #22 + #27): two lines for the curion currently at the top of the visible list. Wraps if the flavor exceeds the line width.
-  - Line 1: SF flavor text (Issue #22). Missing flavor falls back to `(フレーバー未登録)`.
+  - Line 1: SF flavor text (Issue #22, Issue #68 Phase 3a). The flavor is selected via `NounDatabase::flavor_for(noun, game_state.language)` so EN sessions render `flavor_en` (with JA fallback when empty). Missing flavor falls back to `(フレーバー未登録)` (JA) / `(no flavor)` (EN).
   - Line 2: acquisition history (Issue #27) — `入手: YYYY-MM-DD HH:MM  (通算 N回目の収集)` in local TZ. Legacy save curions without `acquisition_index` show `(履歴情報なし)` instead of the count.
 
 **Encyclopedia right pane:**

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -427,13 +427,13 @@ mod tests {
     #[test]
     fn flavor_for_en_returns_english_when_present() {
         let db = NounDatabase::load_embedded().expect("Failed to load noun database");
-        // phenomena.json の最初のエントリ (夜明け) は flavor_en が "A particle of hope..." で始まる
-        let en = db.flavor_for("夜明け", Language::En).expect("EN flavor");
+        // phenomena.json の最初のエントリ (朝) は flavor_en が "A particle of hope..." で始まる
+        let en = db.flavor_for("朝", Language::En).expect("EN flavor");
         assert!(
             en.starts_with("A particle") || en.starts_with("A "),
             "EN flavor should be English, got: {en:?}"
         );
-        let ja = db.flavor_for("夜明け", Language::Ja).expect("JA flavor");
+        let ja = db.flavor_for("朝", Language::Ja).expect("JA flavor");
         assert_ne!(en, ja, "EN flavor should differ from JA");
     }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -28,6 +28,8 @@ pub struct NounEntry {
     pub weight: f64,
     /// SF 寓話風のフレーバーテキスト（Issue #22）。
     /// 既存 JSON との後方互換性のため `#[serde(default)]` で省略可能。
+    /// Phase 3 (#68) で `flavor_for(noun, lang)` 経由の lang gate に通している。
+    /// 現状 268 件全件で埋まっており `test_flavor_field_loaded_for_all_nouns` で保証。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flavor: Option<String>,
     /// Issue #65 Phase 2 で追加した英語版フレーバー。
@@ -430,8 +432,12 @@ mod tests {
         // phenomena.json の最初のエントリ (朝) は flavor_en が "A particle of hope..." で始まる
         let en = db.flavor_for("朝", Language::En).expect("EN flavor");
         assert!(
-            en.starts_with("A particle") || en.starts_with("A "),
-            "EN flavor should be English, got: {en:?}"
+            en.is_ascii() || !en.contains('。'),
+            "EN flavor should not contain JA sentence terminator, got: {en:?}"
+        );
+        assert!(
+            en.starts_with("A "),
+            "EN flavor should start with English article, got: {en:?}"
         );
         let ja = db.flavor_for("朝", Language::Ja).expect("JA flavor");
         assert_ne!(en, ja, "EN flavor should differ from JA");

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,4 +1,5 @@
 use crate::curion::{Category, Curion, Rarity};
+use crate::i18n::Language;
 use crate::latent::{
     cosine_similarity, latent_from_seed, project_unit, prototype_for_noun, LatentVector,
 };
@@ -29,6 +30,12 @@ pub struct NounEntry {
     /// 既存 JSON との後方互換性のため `#[serde(default)]` で省略可能。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flavor: Option<String>,
+    /// Issue #65 Phase 2 で追加した英語版フレーバー。
+    /// 既存 JSON との後方互換性のため `#[serde(default)]` で省略可能。
+    /// Phase 3 (#68) で `flavor_for(noun, lang)` 経由の lang gate に通している。
+    /// 空文字または未設定の場合は JA `flavor` にフォールバックする (Phase 4 と同じパターン)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flavor_en: Option<String>,
 }
 
 /// 名詞データベース
@@ -80,9 +87,21 @@ impl NounDatabase {
             .find(|e| e.name == noun_name)
     }
 
-    /// 名詞名から該当するフレーバーテキストを取得する（未設定なら None）
-    pub fn flavor_for(&self, noun_name: &str) -> Option<&str> {
-        self.find_entry(noun_name).and_then(|e| e.flavor.as_deref())
+    /// 名詞名から該当するフレーバーテキストを言語別に取得する（未設定なら None）。
+    ///
+    /// Issue #68 Phase 3a: `lang == En` のときは `flavor_en` を返し、空文字
+    /// または未設定なら JA `flavor` にフォールバックする (Phase 4 同パターン)。
+    /// 合成専用 noun (`蒸気` / `残骸` 等、`data/nouns/*.json` に存在しない名詞)
+    /// は `None` を返す。
+    pub fn flavor_for(&self, noun_name: &str, lang: Language) -> Option<&str> {
+        let entry = self.find_entry(noun_name)?;
+        match lang {
+            Language::Ja => entry.flavor.as_deref(),
+            Language::En => match entry.flavor_en.as_deref() {
+                Some(s) if !s.is_empty() => Some(s),
+                _ => entry.flavor.as_deref(),
+            },
+        }
     }
 
     /// Issue #63: noun の Japanese ID から English 表示名を引く。
@@ -387,12 +406,81 @@ mod tests {
         );
     }
 
-    /// Issue #22: flavor_for ヘルパは存在しない名詞には None を返す。
+    /// Issue #22 / Issue #68 Phase 3a: flavor_for ヘルパは存在しない名詞には None を返し、
+    /// 言語別の flavor を取得できる。
     #[test]
     fn test_flavor_for_helper() {
         let db = NounDatabase::load_embedded().expect("Failed to load noun database");
-        assert!(db.flavor_for("魚").is_some(), "魚 should have a flavor");
-        assert!(db.flavor_for("__not_exist__").is_none());
+        assert!(
+            db.flavor_for("魚", Language::Ja).is_some(),
+            "魚 should have a JA flavor"
+        );
+        assert!(
+            db.flavor_for("魚", Language::En).is_some(),
+            "魚 should resolve an EN flavor (en or JA fallback)"
+        );
+        assert!(db.flavor_for("__not_exist__", Language::Ja).is_none());
+        assert!(db.flavor_for("__not_exist__", Language::En).is_none());
+    }
+
+    /// Issue #68 Phase 3a: `flavor_en` が設定されているときは En で英文を返す。
+    #[test]
+    fn flavor_for_en_returns_english_when_present() {
+        let db = NounDatabase::load_embedded().expect("Failed to load noun database");
+        // phenomena.json の最初のエントリ (夜明け) は flavor_en が "A particle of hope..." で始まる
+        let en = db.flavor_for("夜明け", Language::En).expect("EN flavor");
+        assert!(
+            en.starts_with("A particle") || en.starts_with("A "),
+            "EN flavor should be English, got: {en:?}"
+        );
+        let ja = db.flavor_for("夜明け", Language::Ja).expect("JA flavor");
+        assert_ne!(en, ja, "EN flavor should differ from JA");
+    }
+
+    /// Issue #68 Phase 3a: `flavor_en` が空文字または未設定の場合は JA にフォールバック。
+    #[test]
+    fn flavor_for_falls_back_to_ja_when_en_empty() {
+        // 空文字 flavor_en
+        let entry_empty = NounEntry {
+            name: "テスト".to_string(),
+            reading: "てすと".to_string(),
+            english: "test".to_string(),
+            weight: 1.0,
+            flavor: Some("日本語フレーバー。".to_string()),
+            flavor_en: Some(String::new()),
+        };
+        // None flavor_en
+        let entry_none = NounEntry {
+            name: "テスト2".to_string(),
+            reading: "てすと2".to_string(),
+            english: "test2".to_string(),
+            weight: 1.0,
+            flavor: Some("日本語フレーバー2。".to_string()),
+            flavor_en: None,
+        };
+
+        let mut entries = HashMap::new();
+        entries.insert(Category::Abstract, vec![entry_empty, entry_none]);
+        let db = NounDatabase { entries };
+
+        assert_eq!(
+            db.flavor_for("テスト", Language::En),
+            Some("日本語フレーバー。"),
+            "empty flavor_en should fall back to JA"
+        );
+        assert_eq!(
+            db.flavor_for("テスト2", Language::En),
+            Some("日本語フレーバー2。"),
+            "missing flavor_en should fall back to JA"
+        );
+    }
+
+    /// Issue #68 Phase 3a: 存在しない名詞は EN/JA いずれも None。
+    #[test]
+    fn flavor_for_returns_none_for_unknown_noun() {
+        let db = NounDatabase::load_embedded().expect("Failed to load noun database");
+        assert!(db.flavor_for("__unknown_noun__", Language::Ja).is_none());
+        assert!(db.flavor_for("__unknown_noun__", Language::En).is_none());
     }
 
     // -----------------------------------------------------------------

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2503,14 +2503,19 @@ impl App {
             filtered.get(focus_index).copied()
         };
 
+        let lang = self.game_state.language;
+        let flavor_unset = match lang {
+            crate::i18n::Language::Ja => "(フレーバー未登録)",
+            crate::i18n::Language::En => "(no flavor)",
+        };
         let flavor_text: String = focused
             .and_then(|c| {
                 self.generator
                     .database()
-                    .flavor_for(&c.noun)
+                    .flavor_for(&c.noun, lang)
                     .map(|s| s.to_string())
             })
-            .unwrap_or_else(|| "(フレーバー未登録)".to_string());
+            .unwrap_or_else(|| flavor_unset.to_string());
         // Issue #38: 装備中の curion なら title に [装備中] マーカー
         let equipped_id = player.equipment.curion_id.as_deref();
         let is_focused_equipped = focused
@@ -2824,7 +2829,10 @@ impl App {
 
         let mut out: Vec<Line<'_>> = vec![main_line];
         if acquired {
-            if let Some(flavor) = entry.flavor.as_deref() {
+            // Issue #68 Phase 3a: flavor も lang gate を通す。EN 表示時に flavor_en があれば英文を、
+            // 空または未設定なら JA フォールバック。
+            let lang = self.game_state.language;
+            if let Some(flavor) = self.generator.database().flavor_for(&entry.name, lang) {
                 // インデント `  ` の表示幅を引いて切り詰める
                 let indent = "  ";
                 let budget = inner_width.saturating_sub(UnicodeWidthStr::width(indent));


### PR DESCRIPTION
## 関連 Issue
closes #68

## 背景

Phase 2 (#65) で全 268 noun に \`flavor_en\` フィールドを追加済みだったが、UI は依然として JA \`flavor\` 固定で表示していた。本 PR で Phase 3a (lang gate) + Phase 3b (語彙統一) の両方を完了させる。

## Phase 3a: flavor lang gate

- \`NounEntry\` に \`flavor_en: Option<String>\` フィールドを追加（\`#[serde(default)]\`、JSON は既に揃っているので破壊的変更なし）
- \`NounDatabase::flavor_for(noun_name, lang)\` に \`lang\` 引数を追加。En 時は \`flavor_en\`、空文字または None なら JA \`flavor\` にフォールバック（Phase 4 と同じパターン）
- UI 統合: \`src/ui.rs:2510\` Collection 詳細ペイン、\`src/ui.rs:2827\` Dictionary 図鑑エントリ。未登録プレースホルダも \`(no flavor)\` / \`(フレーバー未登録)\` で lang 切替
- 合成専用 noun (蒸気 / 残骸 等、\`data/nouns/*.json\` 未登録) は従来通り None
- 新規テスト 3 件追加

## Phase 3b: interest → curiosity 統一 (案 A 採用)

リポ名 \`curion\` (= curiosity) との整合を最大化するため、\`flavor_en\` 内で curiosity と同義に使われていた \`interest\` を全件 \`curiosity\` に統一:

- \`data/nouns/abstracts.json\`: 52 件
- \`data/nouns/animals.json\`: 59 件
- \`data/nouns/foods.json\`: 2 件
- 計 113 件、英語慣用句 \`point of interest\` 等はデータ中に存在しなかったため対象外残しなし

## 検証

- cargo test: **278 passed** (前回 275 + 新規 3 件)
- cargo clippy --all-targets -- -D warnings: clean
- cargo fmt 適用済

## docs / CHANGELOG

- \`docs/spec.md\` に \"Phase 3 (Issue #68): Flavor i18n\" セクション追加、L46 の \`flavor_en\` 説明を \"Phase 3 完了\" に更新
- \`DESIGN.md\` の flavor 行記述を \`flavor_for(noun, lang)\` 経由に更新
- \`CHANGELOG.md\` Unreleased > Added に Phase 3a / 3b エントリ追加

## 残懸念

- \`animals.json:120\` で \"particle of curiosity, as though curiosity itself were personified\" のように curiosity が 1 行に 2 回出る軽い反復が発生（案 A の機械置換結果）。意味は通る範囲。文体磨きは後続 polish Issue で

## Test plan
- [ ] \`cargo run -- --lang en\` で Collection 詳細・図鑑モードの flavor が英語で出ること目視
- [ ] \`cargo run -- --lang ja\` で JA flavor 表示が無傷であること目視
- [ ] 合成専用 noun (例: 蒸気) を引いて未登録プレースホルダが lang 切替されること目視