### PR TITLE
feat: 手動生成3分クールダウン + 1時間自動ドロー (#78)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -7,6 +7,22 @@
 - The UUID is hashed with SHA-256 to produce a deterministic 32-byte digest.
 - Digest bytes are sliced to determine curion attributes.
 
+### Manual Generation Cooldown (Issue #78)
+
+- **Cooldown**: 3 minutes (180 seconds) per manual generation.
+- **Field**: `last_manual_generate_at: Option<DateTime<Utc>>` — updated on each successful Space-key generation.
+- `None` (first launch or legacy save) means no cooldown; generation is immediately available.
+- While on cooldown, the footer hint shows remaining seconds (e.g. `Space  Generate (42s)`).
+
+### Auto-Draw System (Issue #78)
+
+- **Interval**: 1 hour (3600 seconds).
+- On each tick, the app checks how many 1-hour intervals have elapsed since `last_auto_draw_at`.
+- Each pending draw is applied with `acquired_at` set to the timestamp when it *would have* occurred (retroactive).
+- A log entry is appended for each auto-draw in the format `[HH:MM] <name> を入手`.
+- **Field**: `last_auto_draw_at: Option<DateTime<Utc>>` — updated to the latest drawn timestamp after processing.
+- `None` (first launch or legacy save) suppresses auto-draw entirely to avoid a large batch on first run.
+
 ## Curion Attributes
 
 Each curion has:

--- a/src/cooldown.rs
+++ b/src/cooldown.rs
@@ -49,16 +49,11 @@ pub fn generate_remaining_seconds(last_at: Option<DateTime<Utc>>, now: DateTime<
 
 /// 自動ドローが何回分溜まっているかを返す（上限なし）。
 ///
-/// `last_at = None`（初回・旧セーブ）→ 0 回（起動時に大量ドローする体験は避ける）。
-/// `last_at = Some(t)` → `(now - t) / AUTO_DRAW_INTERVAL_SECS` の商を返す。
-pub fn pending_auto_draws(last_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> u32 {
-    match last_at {
-        None => 0,
-        Some(t) => {
-            let elapsed = (now - t).num_seconds().max(0);
-            (elapsed / AUTO_DRAW_INTERVAL_SECS) as u32
-        }
-    }
+/// `last_at` は `None` を取らない（呼び出し元で `if let Some` 済み）。
+/// `(now - last_at) / AUTO_DRAW_INTERVAL_SECS` の商を返す。
+pub fn pending_auto_draws(last_at: DateTime<Utc>, now: DateTime<Utc>) -> u32 {
+    let elapsed = (now - last_at).num_seconds().max(0);
+    (elapsed / AUTO_DRAW_INTERVAL_SECS) as u32
 }
 
 /// n 番目（0 始まり）の自動ドローが行われた「はずの時刻」を返す。
@@ -66,8 +61,7 @@ pub fn pending_auto_draws(last_at: Option<DateTime<Utc>>, now: DateTime<Utc>) ->
 /// `last_at + (n+1) * AUTO_DRAW_INTERVAL_SECS` 秒後の時刻。
 /// ログに「14:00 ○○ を入手」のように積まれ、プレイヤーが遡って気づけるようにする。
 pub fn auto_draw_timestamp(last_at: DateTime<Utc>, n: u32) -> DateTime<Utc> {
-    last_at
-        + chrono::Duration::seconds(AUTO_DRAW_INTERVAL_SECS * (n as i64 + 1))
+    last_at + chrono::Duration::seconds(AUTO_DRAW_INTERVAL_SECS * (n as i64 + 1))
 }
 
 /// クールダウン進捗を計算する。
@@ -182,6 +176,171 @@ mod tests {
         // 2026-05-16 12:00:00 UTC を起点に (時, 分) のオフセットを足す
         let base = Utc.with_ymd_and_hms(2026, 5, 16, 12, 0, 0).unwrap();
         base + chrono::Duration::hours(h) + chrono::Duration::minutes(m)
+    }
+
+    /// 秒単位のオフセットで DateTime を作るヘルパー
+    fn dt_secs(secs: i64) -> DateTime<Utc> {
+        let base = Utc.with_ymd_and_hms(2026, 5, 16, 12, 0, 0).unwrap();
+        base + chrono::Duration::seconds(secs)
+    }
+
+    // ── Issue #78: can_generate_manually ──────────────────────────────
+
+    /// B-1: elapsed=179 秒 → クールダウン中のため生成不可
+    #[test]
+    fn can_generate_manually_false_when_elapsed_is_179_secs() {
+        let last = dt_secs(0);
+        let now = dt_secs(179);
+        assert!(!can_generate_manually(Some(last), now));
+    }
+
+    /// B-2: elapsed=180 秒（境界値）→ クールダウン満了のため生成可能
+    #[test]
+    fn can_generate_manually_true_when_elapsed_is_exactly_cooldown() {
+        let last = dt_secs(0);
+        let now = dt_secs(180);
+        assert!(can_generate_manually(Some(last), now));
+    }
+
+    /// N-1: last_at=None → 初回起動は無条件で生成可能
+    #[test]
+    fn can_generate_manually_true_when_last_at_is_none() {
+        assert!(can_generate_manually(None, dt_secs(0)));
+    }
+
+    /// N-2: elapsed=180 → 生成可能（境界の再確認）
+    #[test]
+    fn can_generate_manually_true_when_elapsed_equals_cooldown_boundary() {
+        let last = dt_secs(0);
+        let now = dt_secs(MANUAL_GENERATE_COOLDOWN_SECS);
+        assert!(can_generate_manually(Some(last), now));
+    }
+
+    /// N-3: elapsed=181 → 境界を超えても生成可能
+    #[test]
+    fn can_generate_manually_true_when_elapsed_exceeds_cooldown() {
+        let last = dt_secs(0);
+        let now = dt_secs(MANUAL_GENERATE_COOLDOWN_SECS + 1);
+        assert!(can_generate_manually(Some(last), now));
+    }
+
+    // ── Issue #78: generate_remaining_seconds ────────────────────────
+
+    /// B-3: elapsed=179 → 残り 1 秒
+    #[test]
+    fn generate_remaining_seconds_is_1_when_elapsed_is_179() {
+        let last = dt_secs(0);
+        let now = dt_secs(179);
+        assert_eq!(generate_remaining_seconds(Some(last), now), 1);
+    }
+
+    /// B-4: elapsed=180 → 残り 0 秒（生成可能）
+    #[test]
+    fn generate_remaining_seconds_is_0_when_elapsed_equals_cooldown() {
+        let last = dt_secs(0);
+        let now = dt_secs(180);
+        assert_eq!(generate_remaining_seconds(Some(last), now), 0);
+    }
+
+    /// N-4: last_at=None → 残り 0 秒
+    #[test]
+    fn generate_remaining_seconds_is_0_when_last_at_is_none() {
+        assert_eq!(generate_remaining_seconds(None, dt_secs(0)), 0);
+    }
+
+    /// N-5: elapsed=60 → 残り 120 秒
+    #[test]
+    fn generate_remaining_seconds_is_120_when_elapsed_is_60() {
+        let last = dt_secs(0);
+        let now = dt_secs(60);
+        assert_eq!(generate_remaining_seconds(Some(last), now), 120);
+    }
+
+    /// N-6: elapsed=180 → 残り 0 秒（境界値）
+    #[test]
+    fn generate_remaining_seconds_is_0_when_elapsed_is_180() {
+        let last = dt_secs(0);
+        let now = dt_secs(180);
+        assert_eq!(generate_remaining_seconds(Some(last), now), 0);
+    }
+
+    /// K-1: now < last_at（クロックスキュー）→ MANUAL_GENERATE_COOLDOWN_SECS を返す
+    #[test]
+    fn generate_remaining_seconds_returns_full_cooldown_on_clock_skew() {
+        let last = dt_secs(100); // last_at が now より未来
+        let now = dt_secs(0);
+        assert_eq!(
+            generate_remaining_seconds(Some(last), now),
+            MANUAL_GENERATE_COOLDOWN_SECS
+        );
+    }
+
+    // ── Issue #78: pending_auto_draws ────────────────────────────────
+
+    /// B-5: elapsed=3599 → pending=0（インターバル未満）
+    #[test]
+    fn pending_auto_draws_is_0_when_elapsed_is_3599() {
+        let last = dt_secs(0);
+        let now = dt_secs(3599);
+        assert_eq!(pending_auto_draws(last, now), 0);
+    }
+
+    /// B-6: elapsed=3600 → pending=1（インターバルちょうど）
+    #[test]
+    fn pending_auto_draws_is_1_when_elapsed_is_exactly_one_interval() {
+        let last = dt_secs(0);
+        let now = dt_secs(3600);
+        assert_eq!(pending_auto_draws(last, now), 1);
+    }
+
+    /// B-7: elapsed=7199 → pending=1（2 インターバル未満）
+    #[test]
+    fn pending_auto_draws_is_1_when_elapsed_is_7199() {
+        let last = dt_secs(0);
+        let now = dt_secs(7199);
+        assert_eq!(pending_auto_draws(last, now), 1);
+    }
+
+    /// N-8: elapsed=3600 → pending=1
+    #[test]
+    fn pending_auto_draws_is_1_when_elapsed_is_one_interval() {
+        let last = dt_secs(0);
+        let now = dt_secs(AUTO_DRAW_INTERVAL_SECS);
+        assert_eq!(pending_auto_draws(last, now), 1);
+    }
+
+    /// N-9: elapsed=7200 → pending=2
+    #[test]
+    fn pending_auto_draws_is_2_when_elapsed_is_two_intervals() {
+        let last = dt_secs(0);
+        let now = dt_secs(AUTO_DRAW_INTERVAL_SECS * 2);
+        assert_eq!(pending_auto_draws(last, now), 2);
+    }
+
+    /// K-2: now < last_at（クロックスキュー）→ pending=0（負の elapsed は 0 扱い）
+    #[test]
+    fn pending_auto_draws_is_0_on_clock_skew() {
+        let last = dt_secs(1000); // last_at が now より未来
+        let now = dt_secs(0);
+        assert_eq!(pending_auto_draws(last, now), 0);
+    }
+
+    // ── Issue #78: auto_draw_timestamp ───────────────────────────────
+
+    /// B-8 / N-10: auto_draw_timestamp(last_at, n=0) = last_at + 3600秒
+    #[test]
+    fn auto_draw_timestamp_n0_is_last_at_plus_one_interval() {
+        let last = dt_secs(0);
+        let expected = dt_secs(AUTO_DRAW_INTERVAL_SECS);
+        assert_eq!(auto_draw_timestamp(last, 0), expected);
+    }
+
+    /// B-8 / N-11: auto_draw_timestamp(last_at, n=2) = last_at + 10800秒
+    #[test]
+    fn auto_draw_timestamp_n2_is_last_at_plus_three_intervals() {
+        let last = dt_secs(0);
+        let expected = dt_secs(AUTO_DRAW_INTERVAL_SECS * 3);
+        assert_eq!(auto_draw_timestamp(last, 2), expected);
     }
 
     #[test]

--- a/src/cooldown.rs
+++ b/src/cooldown.rs
@@ -16,6 +16,60 @@ use chrono::{DateTime, Utc};
 /// クールダウン満了までの時間 (時間単位)。
 pub const FULL_HOURS: f64 = 4.0;
 
+// ── Issue #78: 手動生成クールダウン / 自動ドロー ────────────────────────────
+
+/// 手動生成（Space キー）のクールダウン秒数。3 分。
+pub const MANUAL_GENERATE_COOLDOWN_SECS: i64 = 180;
+
+/// 自動ドローのインターバル秒数。1 時間。
+pub const AUTO_DRAW_INTERVAL_SECS: i64 = 3600;
+
+/// 手動生成が可能かどうかを返す。
+///
+/// - `last_at = None`（初回）→ 生成可能
+/// - 前回生成から [`MANUAL_GENERATE_COOLDOWN_SECS`] 秒以上経過 → 生成可能
+/// - それ以外 → 生成不可
+pub fn can_generate_manually(last_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    match last_at {
+        None => true,
+        Some(t) => (now - t).num_seconds() >= MANUAL_GENERATE_COOLDOWN_SECS,
+    }
+}
+
+/// 手動生成の残り秒数（0 なら生成可能）。
+pub fn generate_remaining_seconds(last_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> i64 {
+    match last_at {
+        None => 0,
+        Some(t) => {
+            let elapsed = (now - t).num_seconds().max(0);
+            (MANUAL_GENERATE_COOLDOWN_SECS - elapsed).max(0)
+        }
+    }
+}
+
+/// 自動ドローが何回分溜まっているかを返す（上限なし）。
+///
+/// `last_at = None`（初回・旧セーブ）→ 0 回（起動時に大量ドローする体験は避ける）。
+/// `last_at = Some(t)` → `(now - t) / AUTO_DRAW_INTERVAL_SECS` の商を返す。
+pub fn pending_auto_draws(last_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> u32 {
+    match last_at {
+        None => 0,
+        Some(t) => {
+            let elapsed = (now - t).num_seconds().max(0);
+            (elapsed / AUTO_DRAW_INTERVAL_SECS) as u32
+        }
+    }
+}
+
+/// n 番目（0 始まり）の自動ドローが行われた「はずの時刻」を返す。
+///
+/// `last_at + (n+1) * AUTO_DRAW_INTERVAL_SECS` 秒後の時刻。
+/// ログに「14:00 ○○ を入手」のように積まれ、プレイヤーが遡って気づけるようにする。
+pub fn auto_draw_timestamp(last_at: DateTime<Utc>, n: u32) -> DateTime<Utc> {
+    last_at
+        + chrono::Duration::seconds(AUTO_DRAW_INTERVAL_SECS * (n as i64 + 1))
+}
+
 /// クールダウン進捗を計算する。
 ///
 /// - 戻り値は `0.0..=1.0` に clamp 済み

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,14 @@ pub fn run_tui(profile_manager: &ProfileManager) -> Result<()> {
     let login_bonus = game_state.process_login();
     // Issue #30: 起動時に期限切れキュリオンを自動削除し、UI に通知メッセージを残す。
     let expired = game_state.prune_expired_curions(chrono::Utc::now());
+
+    // Issue #78: 自動ドロー基準時刻の初期化。
+    // last_auto_draw_at = None（初回・旧セーブ）の場合、大量ドローを防ぐため
+    // 現在時刻を基準時刻にセットする（これ以降からカウント開始）。
+    if game_state.player.last_auto_draw_at.is_none() {
+        game_state.player.last_auto_draw_at = Some(chrono::Utc::now());
+    }
+
     save_manager.save(&game_state)?;
 
     // Terminal setup

--- a/src/player.rs
+++ b/src/player.rs
@@ -389,7 +389,8 @@ impl Player {
         curion.acquisition_index = Some(self.total_acquisitions);
 
         // Issue #25: 最終収集時刻を更新 (レア出現予告クールダウンをリセット)
-        self.last_collection_at = Some(Utc::now());
+        // acquired_at を使うことで、自動ドロー時に渡されたドロー時刻と整合させる。
+        self.last_collection_at = Some(curion.acquired_at);
 
         // Issue #29: SAN 値をレアリティに応じて回復 (Common +0.5 〜 Legendary +15.0)
         self.san = apply_gain(self.san, san_gain_for_acquisition(curion.rarity));
@@ -1179,6 +1180,8 @@ mod tests {
         assert_eq!(player.guaranteed_tickets.common, 0);
         assert_eq!(player.guaranteed_tickets.rare, 0);
         assert_eq!(player.guaranteed_tickets.epic, 0);
+        assert_eq!(player.last_manual_generate_at, None);
+        assert_eq!(player.last_auto_draw_at, None);
     }
 
     // -----------------------------------------------------------------

--- a/src/player.rs
+++ b/src/player.rs
@@ -184,6 +184,22 @@ pub struct Player {
     #[serde(default)]
     pub last_collection_at: Option<DateTime<Utc>>,
 
+    /// Issue #78: 手動生成（Space キー）の最終実行時刻。
+    ///
+    /// `generate_curion` 成功時に更新される。
+    /// `None`（初回・旧セーブ）はクールダウンなし（即生成可能）扱い。
+    /// 旧セーブには無いため `#[serde(default)]` (= None で復元)。
+    #[serde(default)]
+    pub last_manual_generate_at: Option<DateTime<Utc>>,
+
+    /// Issue #78: 自動ドロー（1 時間インターバル）の最終ドロー時刻。
+    ///
+    /// 起動時に `pending_auto_draws` を計算し、溜まった分を一括適用した後に更新。
+    /// `None`（初回・旧セーブ）は自動ドローを発生させない（初回大量ドロー防止）。
+    /// 旧セーブには無いため `#[serde(default)]` (= None で復元)。
+    #[serde(default)]
+    pub last_auto_draw_at: Option<DateTime<Utc>>,
+
     /// SAN 値 (正気度) (Issue #29)
     ///
     /// 0.0〜100.0 の `f64`。初期値 100.0。
@@ -303,6 +319,8 @@ impl Player {
             max_combo: 0,
             total_acquisitions: 0,
             last_collection_at: None,
+            last_manual_generate_at: None,
+            last_auto_draw_at: None,
             san: SAN_MAX,
             equipment: EquipmentSlot::default(),
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,7 +16,10 @@ use uuid::Uuid;
 
 use jiwa::{RevealHandle, RevealOpts, Rgb};
 
-use crate::cooldown::{cooldown_progress, current_rarity_probabilities, remaining_seconds};
+use crate::cooldown::{
+    auto_draw_timestamp, can_generate_manually, cooldown_progress, current_rarity_probabilities,
+    generate_remaining_seconds, pending_auto_draws, remaining_seconds,
+};
 use crate::curion::{Category, Curion, Rarity};
 use crate::evolution::{sort_progress_by_urgency, EvolutionDatabase};
 use crate::generator::CurionGenerator;
@@ -920,14 +923,33 @@ impl App {
     }
 
     pub fn generate_curion(&mut self) -> Result<()> {
+        let now = chrono::Utc::now();
+
+        // Issue #78: 手動生成は 3 分クールダウン（ストック上限 1 個）。
+        // クールダウン中の Space 押下は無視する。
+        if !can_generate_manually(self.game_state.player.last_manual_generate_at, now) {
+            return Ok(());
+        }
+
+        self.generate_curion_internal(now)?;
+
+        // Issue #78: 手動生成成功時に last_manual_generate_at を更新。
+        self.game_state.player.last_manual_generate_at = Some(now);
+
+        Ok(())
+    }
+
+    /// 内部生成処理（手動・自動ドロー共通）。
+    ///
+    /// `now` を引数で受け取り、自動ドロー時は「ドローされたはずの時刻」を渡せるようにする。
+    fn generate_curion_internal(&mut self, now: chrono::DateTime<chrono::Utc>) -> Result<()> {
         let guid = Uuid::new_v4();
         // Issue #25: 収集後 X 時間でレア確率が段階的に上昇する。
         // クールダウン満了時 (progress=1.0) に最大ボーナスでロールする。
-        let progress = cooldown_progress(
-            self.game_state.player.last_collection_at,
-            chrono::Utc::now(),
-        );
-        let curion = self.generator.generate_with_bonus(guid, progress)?;
+        let progress = cooldown_progress(self.game_state.player.last_collection_at, now);
+        let mut curion = self.generator.generate_with_bonus(guid, progress)?;
+        // 自動ドロー時は acquired_at をドローされたはずの時刻に上書き。
+        curion.acquired_at = now;
         let revealed_name = self.display_curion_name(&curion);
         self.game_state.add_curion(curion);
         self.latest_reveal = Some(RevealHandle::start(
@@ -982,9 +1004,27 @@ impl App {
 
     pub fn on_tick(&mut self) {
         if self.guid_timer.elapsed() >= self.guid_interval {
-            let _ = self.generate_curion();
+            // guid_timer による自動生成は手動クールダウンゲートをバイパスして直接呼ぶ。
+            let _ = self.generate_curion_internal(chrono::Utc::now());
         }
         self.game_state.player.add_play_time(1);
+
+        // Issue #78: 1 時間自動ドロー処理（tick ごとにチェック）。
+        // pending_auto_draws が 1 以上なら、ドローされたはずの時刻で順番に適用する。
+        let now = chrono::Utc::now();
+        if let Some(last_at) = self.game_state.player.last_auto_draw_at {
+            let count = pending_auto_draws(Some(last_at), now);
+            if count > 0 {
+                for i in 0..count {
+                    let draw_time = auto_draw_timestamp(last_at, i);
+                    let _ = self.generate_curion_internal(draw_time);
+                }
+                // last_auto_draw_at を最後のドロー時刻に更新。
+                let new_last = auto_draw_timestamp(last_at, count - 1);
+                self.game_state.player.last_auto_draw_at = Some(new_last);
+                self.dirty = true;
+            }
+        }
 
         if let Some((_, timestamp)) = self.save_message {
             if timestamp.elapsed() > self.save_message_duration {
@@ -1224,6 +1264,30 @@ impl App {
             ]
         };
 
+        // Issue #78: [Space] Generate ヒントをクールダウン状態で切替。
+        // 生成可能 → key_rare（青）、クールダウン中 → key_gray + 残り秒数表示。
+        let now_for_footer = chrono::Utc::now();
+        let remaining_secs = generate_remaining_seconds(
+            self.game_state.player.last_manual_generate_at,
+            now_for_footer,
+        );
+        let space_generate_spans: [Span<'static>; 2] = if remaining_secs == 0 {
+            key_rare("Space", crate::i18n::t("help.generate", lang))
+        } else {
+            let text = format!(
+                "{} ({}s)",
+                crate::i18n::t("help.generate", lang),
+                remaining_secs
+            );
+            [
+                Span::styled(
+                    " Space ".to_string(),
+                    Style::default().fg(Color::DarkGray).bg(Color::Gray),
+                ),
+                Span::styled(format!(" {text}  "), Style::default().fg(Color::DarkGray)),
+            ]
+        };
+
         // Issue #31: フィルタ入力中は専用ヘルプを出す
         if self.filter_mode {
             let mut spans: Vec<Span<'static>> = Vec::new();
@@ -1265,14 +1329,14 @@ impl App {
                 spans.extend(key_dark("j/k", crate::i18n::t("help.category_move", lang)));
                 spans.extend(key_rare("J/K", crate::i18n::t("help.section_switch", lang)));
                 spans.extend(key_epic("/", crate::i18n::t("help.filter", lang)));
-                spans.extend(key_rare("Space", crate::i18n::t("help.generate", lang)));
+                spans.extend(space_generate_spans.clone());
                 tail(&mut spans);
             }
             Tab::Collection if self.current_section_index() == 0 => {
                 spans.extend(key_dark("j/k", crate::i18n::t("help.scroll", lang)));
                 spans.extend(key_rare("J/K", crate::i18n::t("help.section_switch", lang)));
                 spans.extend(key_epic("/", crate::i18n::t("help.filter", lang)));
-                spans.extend(key_rare("Space", crate::i18n::t("help.generate", lang)));
+                spans.extend(space_generate_spans.clone());
                 tail(&mut spans);
             }
             Tab::Achievements if self.current_section_index() == 0 => {
@@ -1284,7 +1348,7 @@ impl App {
                     spans.extend(key_rare("J/K", crate::i18n::t("help.section_switch", lang)));
                 }
                 spans.extend(key_epic("Enter", crate::i18n::t("help.claim_reward", lang)));
-                spans.extend(key_rare("Space", crate::i18n::t("help.generate", lang)));
+                spans.extend(space_generate_spans.clone());
                 tail(&mut spans);
             }
             Tab::Synthesis => {
@@ -1300,7 +1364,7 @@ impl App {
                     crate::i18n::t("help.synthesize_now", lang),
                 ));
                 spans.extend(key_gray("Esc", crate::i18n::t("help.back", lang)));
-                spans.extend(key_rare("Space", crate::i18n::t("help.generate", lang)));
+                spans.extend(space_generate_spans.clone());
                 tail(&mut spans);
             }
             Tab::Settings => {
@@ -1312,7 +1376,7 @@ impl App {
                 if has_multi_sections {
                     spans.extend(key_rare("J/K", crate::i18n::t("help.section_switch", lang)));
                 }
-                spans.extend(key_rare("Space", crate::i18n::t("help.generate", lang)));
+                spans.extend(space_generate_spans.clone());
                 tail(&mut spans);
             }
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1013,11 +1013,19 @@ impl App {
         // pending_auto_draws が 1 以上なら、ドローされたはずの時刻で順番に適用する。
         let now = chrono::Utc::now();
         if let Some(last_at) = self.game_state.player.last_auto_draw_at {
-            let count = pending_auto_draws(Some(last_at), now);
+            let count = pending_auto_draws(last_at, now);
             if count > 0 {
                 for i in 0..count {
                     let draw_time = auto_draw_timestamp(last_at, i);
                     let _ = self.generate_curion_internal(draw_time);
+                    // Issue #78: 自動ドローのログ出力（手動生成と同じ形式）
+                    let local_time = draw_time.with_timezone(&chrono::Local);
+                    let time_str = local_time.format("%H:%M").to_string();
+                    if let Some(curion) = self.game_state.player.collection.last() {
+                        let name = self.display_curion_name(curion);
+                        let msg = format!("[{time_str}] {name} を入手");
+                        self.save_message = Some((msg, Instant::now()));
+                    }
                 }
                 // last_auto_draw_at を最後のドロー時刻に更新。
                 let new_last = auto_draw_timestamp(last_at, count - 1);
@@ -1266,10 +1274,10 @@ impl App {
 
         // Issue #78: [Space] Generate ヒントをクールダウン状態で切替。
         // 生成可能 → key_rare（青）、クールダウン中 → key_gray + 残り秒数表示。
-        let now_for_footer = chrono::Utc::now();
+        let now = chrono::Utc::now();
         let remaining_secs = generate_remaining_seconds(
             self.game_state.player.last_manual_generate_at,
-            now_for_footer,
+            now,
         );
         let space_generate_spans: [Span<'static>; 2] = if remaining_secs == 0 {
             key_rare("Space", crate::i18n::t("help.generate", lang))


### PR DESCRIPTION
## 関連 Issue
closes #78

## 変更内容
- 手動生成（Space）に 3 分（180秒）クールダウンゲートを追加。ストック上限 1 個
- 1 時間に 1 体の自動ドロー。ログに時刻付きで通常の入手と同じ形式で流れる
- クールダウン中は footer の Generate ヒントをグレーアウト + 残り秒数表示
- `last_manual_generate_at` / `last_auto_draw_at` フィールドを追加（`#[serde(default)]` で旧セーブ互換）
- `docs/spec.md` に生成クールダウン・自動ドロー仕様を追記